### PR TITLE
Optimizing Reconciliation

### DIFF
--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -118,7 +118,10 @@ class SqliteReconciler(Reconciler):
                     vals.append(f"{val2} ({val1})")
                     vals.append(f"{val1} ({val2})")
 
-        if typ == 'Person':
+
+        ### OPTIMIZE: This seems very expensive
+        ### Can we do it as a preprocessing step somehow?
+        if typ == 'Person-FALSE':
             birth = self.get_year_from_timespan(rec.get('born',{}))
             death = self.get_year_from_timespan(rec.get('died',{}))
             if birth or death:
@@ -140,6 +143,7 @@ class SqliteReconciler(Reconciler):
                     plus_deaths = self.get_keys_like('name', v)
                     if len(plus_deaths) == 1:
                         vals.append(plus_deaths[0])
+                        print(f" %%% Found +death for {rec['data']['id']}")
         return vals
 
 

--- a/pipeline/process/reference_manager.py
+++ b/pipeline/process/reference_manager.py
@@ -30,6 +30,8 @@ class ReferenceManager(object):
             getty_redirects[f] = t
         self.redirects = getty_redirects
 
+        self.ref_count = {}
+
 
     def write_metatypes(self, my_slice):
         # write out our slice of metatypes
@@ -40,7 +42,6 @@ class ReferenceManager(object):
         fh = open(fn, 'w')
         fh.write(json.dumps(self.metatypes_seen))
         fh.close()        
-
 
     def pop_ref(self):
         return self.all_refs.popitem()
@@ -60,6 +61,10 @@ class ReferenceManager(object):
 
     # a ref is {'dist': int, 'type': str}
     def add_ref(self, ref, refs, distance, ctype): 
+        try:
+            self.ref_count[ref] += 1
+        except:
+            self.ref_count[ref] = 1
         xr = self.all_refs[ref]
         dref = self.done_refs[ref]
         if xr is not None:

--- a/pipeline/process/reference_manager.py
+++ b/pipeline/process/reference_manager.py
@@ -92,10 +92,14 @@ class ReferenceManager(object):
                 xr['type'] = ctype
         elif dref is not None:
             # Test Distance
-            if distance is not None and dref['dist'] is not None and dref['dist'] > distance:
-                # Add it back in
-                del self.done_refs[ref]
-                self.all_refs[ref] = {'dist': distance, 'type': ctype}
+            try:
+                if distance is not None and dref['dist'] is not None and dref['dist'] > distance:
+                    # Add it back in
+                    del self.done_refs[ref]
+                    self.all_refs[ref] = {'dist': distance, 'type': ctype}
+            except:
+                print(f" *** dref-dist {dref} > distance {distance}")
+                return None
         elif not ref in refs:
             refs[ref] = {'dist': distance, 'type': ctype}
             if distance == 1 and "vocab.getty.edu/aat" in ref:

--- a/pipeline/process/reference_manager.py
+++ b/pipeline/process/reference_manager.py
@@ -30,7 +30,7 @@ class ReferenceManager(object):
             getty_redirects[f] = t
         self.redirects = getty_redirects
 
-        self.ref_count = {}
+        self.ref_cache = {}
 
 
     def write_metatypes(self, my_slice):
@@ -59,12 +59,16 @@ class ReferenceManager(object):
             # didn't exist anyway
             pass
 
+
+    # OPTIMIZE: This seems unnecessary as type is in the ref key
+    # as ref is now a qua, not a raw URI
+
     # a ref is {'dist': int, 'type': str}
     def add_ref(self, ref, refs, distance, ctype): 
-        try:
-            self.ref_count[ref] += 1
-        except:
-            self.ref_count[ref] = 1
+
+        if distance == 1 and ref in self.ref_cache:
+            return None
+
         xr = self.all_refs[ref]
         dref = self.done_refs[ref]
         if xr is not None:
@@ -94,6 +98,8 @@ class ReferenceManager(object):
                 self.all_refs[ref] = {'dist': distance, 'type': ctype}
         elif not ref in refs:
             refs[ref] = {'dist': distance, 'type': ctype}
+            if distance == 1 and "vocab.getty.edu/aat" in ref:
+                self.ref_cache[ref] = distance
 
     def walk_for_refs(self, node, refs, distance, top=False):
         # Test if we need to record the node

--- a/pipeline/process/utils/mapper_utils.py
+++ b/pipeline/process/utils/mapper_utils.py
@@ -23,6 +23,7 @@ np_precisions = ['', 'Y','M','D', 'h', 'm', 's'] # number of -s in the string
 max_life_delta = np.datetime64('2122-01-01') - np.datetime64('2000-01-01')
 non_four_year_date = re.compile('(-?)([0-9]{2,3})(-[0-9][0-9]-[0-9][0-9]([^0-9].*|$))')
 de_bc_abbr = re.compile('(([0-9][0-9]).([0-9][0-9]).)?v([0-9]{2,3})$')
+valid_date_re = re.compile(r'([0-9]{4})(-[0-1][0-9]-[0-3][0-9]([ T][0-2][0-9]:[0-5][0-9]:[0-5][0-9]Z?$|$))')
 
 
 time_rectype = {
@@ -228,8 +229,6 @@ def make_datetime(value, precision=""):
 	if len(value) == 6 and value.isnumeric():
 		value = f"{value[:4]}-{value:4:}"
 
-	# 1478/79
-
 
 	if value[0] == '-' and value[1].isnumeric():
 		# -1 
@@ -247,7 +246,6 @@ def make_datetime(value, precision=""):
 				return process_np_datetime(dt, value)
 			else:
 				return process_np_datetime(dt, precision)
-
 	elif "bc" in value.lower() or 'b.c' in value.lower():
 		# 1000 BC or 1000 BCE
 		m = bcdate_re.match(value)
@@ -266,9 +264,17 @@ def make_datetime(value, precision=""):
 					return process_np_datetime(dt, "-"+value)
 				else:
 					return process_np_datetime(dt, precision)
-
 		# else: implausible but it might be a valid date in another locale
 		# so just pass it through
+	elif valid_date_re.match(value):
+		try:
+			if not precision:
+				return process_np_datetime(dt, value)
+			else:
+				return process_np_datetime(dt, precision)		
+		except:
+			# okay, maybe not
+			pass
 
 	# dateutils treats year with leading 0s as current century :(
 	# e.g.parser.parse("0052") --> datetime.datetime(2052, 12, 18, 0, 0)

--- a/pipeline/process/utils/mapper_utils.py
+++ b/pipeline/process/utils/mapper_utils.py
@@ -23,8 +23,7 @@ np_precisions = ['', 'Y','M','D', 'h', 'm', 's'] # number of -s in the string
 max_life_delta = np.datetime64('2122-01-01') - np.datetime64('2000-01-01')
 non_four_year_date = re.compile('(-?)([0-9]{2,3})(-[0-9][0-9]-[0-9][0-9]([^0-9].*|$))')
 de_bc_abbr = re.compile('(([0-9][0-9]).([0-9][0-9]).)?v([0-9]{2,3})$')
-valid_date_re = re.compile(r'([0-9]{4})(-[0-1][0-9]-[0-3][0-9]([ T][0-2][0-9]:[0-5][0-9]:[0-5][0-9]Z?$|$))')
-
+valid_date_re = re.compile(r'([0-2][0-9]{3})(-[0-1][0-9]-[0-3][0-9]([ T][0-2][0-9]:[0-5][0-9]:[0-5][0-9]Z?$|$))')
 
 time_rectype = {
 	"Person": ["born", "died", "carried_out", "participated_in"],
@@ -158,13 +157,13 @@ def convert_hebrew_date(dt):
 def process_np_datetime(dt, value):
 	is_bc = dt.astype('<M8[s]').astype(np.int64) < -62135596800
 	start = dt.astype('<M8[s]').astype(str)
+	if ':' in value or 'T' in value:
+		mod = value.count(':') + 1
+	else:
+		mod = 0
 	if value in ['Y', 'M', 'D', 'h', 'm', 's']:
 		prec = value
 	elif is_bc:		
-		if ':' in value or 'T' in value:
-			mod = value.count(':') + 1
-		else:
-			mod = 0
 		prec = np_precisions[value.count('-') + mod]
 	else:
 		prec = np_precisions[value.count('-') + mod +1]
@@ -277,6 +276,7 @@ def make_datetime(value, precision=""):
 				return process_np_datetime(dt, value)
 			else:
 				return process_np_datetime(dt, precision)		
+
 
 	# dateutils treats year with leading 0s as current century :(
 	# e.g.parser.parse("0052") --> datetime.datetime(2052, 12, 18, 0, 0)

--- a/pipeline/process/utils/mapper_utils.py
+++ b/pipeline/process/utils/mapper_utils.py
@@ -268,13 +268,15 @@ def make_datetime(value, precision=""):
 		# so just pass it through
 	elif valid_date_re.match(value):
 		try:
+			dt = np.datetime64(value)
+		except:
+			# I guess not
+			dt = None
+		if dt is not None:
 			if not precision:
 				return process_np_datetime(dt, value)
 			else:
 				return process_np_datetime(dt, precision)		
-		except:
-			# okay, maybe not
-			pass
 
 	# dateutils treats year with leading 0s as current century :(
 	# e.g.parser.parse("0052") --> datetime.datetime(2052, 12, 18, 0, 0)

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -487,7 +487,7 @@ class PooledCache(PGCache):
                 print(f"Making cache table {self.name}")
                 self.conn.rollback()
                 self._make_table()
-        self._close()
+        # self._close()
 
 
     def _connect(self):

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -199,7 +199,7 @@ class PGCache(object):
         rows = cursor.fetchone()
         cursor.close()        
         self.conn.commit()
-        self._close()
+        # self._close()
         if rows:
             rows['source'] = self.config['name']
 
@@ -223,7 +223,7 @@ class PGCache(object):
         rows = cursor.fetchone()
         cursor.close()        
         self.conn.commit()
-        self._close()
+        # self._close()
         if rows:
             rows['source'] = self.config['name']
         return rows
@@ -242,7 +242,7 @@ class PGCache(object):
         with self._cursor() as cursor:
             cursor.execute(qry, params)
             rows = cursor.fetchall()
-        self._close()
+        # self._close()
         return [x[self.key] for x in rows]
 
     # SELECT t.* FROM (SELECT *, row_number() OVER 
@@ -378,7 +378,7 @@ class PGCache(object):
                 self.conn.rollback()                
         cursor.close()
         # sys.stdout.write('S');sys.stdout.flush()
-        self._close()
+        # self._close()
 
     def delete(self, key, _key_type=None):
         if _key_type is None:
@@ -388,7 +388,7 @@ class PGCache(object):
         with self._cursor(internal=False) as cursor:            
             cursor.execute(qry, params)
             self.conn.commit()
-        self._close()
+        # self._close()
 
     def clear(self):
         # WARNING WARNING ... trash all the data in the cache
@@ -413,7 +413,7 @@ class PGCache(object):
         rows = cursor.fetchone()
         cursor.close()
         self.conn.commit()
-        self._close()
+        # self._close()
         # sys.stdout.write('?');sys.stdout.flush()
         return bool(rows)
 

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -21,7 +21,7 @@ class PoolManager(object):
 
     def __init__(self):
         self.mincxn = 2
-        self.maxcxn = 4
+        self.maxcxn = 5
         self.pools = {}
 
     def make_pool(self, name, *args, **kw):
@@ -30,6 +30,7 @@ class PoolManager(object):
 
     def get_conn(self, name, key=None):
         if name in self.pools:
+            print(f"connection requested")
             return self.pools[name].getconn(key)
         else:
             return None

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -506,12 +506,15 @@ class PooledCache(PGCache):
 
     def _close(self, conn=None, is_iter=False):
         if conn is None and is_iter == False:
+            print(f"returned main connection")
             poolman.put_conn(self.pool_name, self.conn)
             self.conn = None
         elif is_iter:
+            print(f"returned iterator")
             poolman.put_conn(self.pool_name, self.iterating_conn)
             self.iterating_conn = None
         elif conn is not None:
+            print(f"returned specific connection")
             poolman.put_conn(self.pool_name, conn)
 
 

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -492,7 +492,7 @@ class PooledCache(PGCache):
 
 
     def _connect(self):
-        print(f"{self.name} requesting connection")
+        print(f"{self.name} requesting connection in _connect")
         self.conn = poolman.get_conn(self.pool_name)
 
     def shutdown(self):
@@ -524,6 +524,7 @@ class PooledCache(PGCache):
 
         # Get a connection from the pool
         if not self.conn:
+            print(f"{self.name} requesting connection in _cursor")
             self.conn = poolman.get_conn(self.pool_name)
         return PGCache._cursor(self, internal, iter)
 

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -17,6 +17,10 @@ import sys
 # pg_restore -a -U pipeline -W --host HOST -d DATABASE wof_data_cache.pgdump 
 
 
+
+# We actually only need two connections per process -- one to stay open for iteration, and one to read/write.
+# This means we can't iterate two different tables at the same time, but that's fine.
+
 class PoolManager(object):
     def __init__(self):
         self.conn = None
@@ -35,461 +39,29 @@ class PoolManager(object):
                 self.iterating_conn = psycopg2.connect(user=user, dbname=dbname)
             self.pool = name
 
-    def get_conn(self, name, key=None, itr=False):
+    def get_conn(self, name, itr=False):
         if itr == False:
             return self.conn
         else:
             return self.iterating_conn
 
-    def put_conn(self, name, key=None, close=False, itr=False):
-        pass
+    def put_conn(self, name, close=False, itr=False):
+        if close:
+            if itr and self.iterating_conn is not None:
+                self.iterating_conn.close()
+                self.iteration_conn = None
+            elif not itr and self.conn is not None:
+                self.conn.close()
+                self.conn = None
 
     def put_all(self, name):
-        pass
-
-class PoolManager_orig(object):
-
-    def __init__(self):
-        self.mincxn = 2
-        self.maxcxn = 5
-        self.pools = {}
-
-    def make_pool(self, name, *args, **kw):
-        if not name in self.pools:
-            self.pools[name] = SimpleConnectionPool(self.mincxn, self.maxcxn, *args, **kw)
-
-    def get_conn(self, name, key=None, itr=False):
-        if name in self.pools:
-            return self.pools[name].getconn(key)
-        else:
-            return None
-
-    def put_conn(self, name, conn, key=None, close=False, itr=False):
-        if name in self.pools:
-            self.pools[name].putconn(conn, key, close)
-        else:
-            return None
-
-    def put_all(self, name):
-        if name in self.pools:
-            conns = list(self.pools[name]._used.values())
-            for conn in conns:
-                try:
-                    conn.commit()
-                except:
-                    pass
-                try:
-                    conn.close()
-                except:
-                    pass
-                try:
-                    self.pools[name].putconn(conn, None, True)
-                except:
-                    pass
-        else:
-            return None
-
-
-
+        self.put_conn(self.pool, close=True)
+        self.put_conn(self.pool, close=True, itr=True)
 
 poolman = PoolManager()
 
-class PGCache(object):
-    def __init__(self, config):
+class PooledCache(object):
 
-        self.config = config
-        self.name = config['name'] + '_' + config['tabletype']
-        self.conn = None
-        self.iterating_conn = None
-
-        if config['connect']:
-            self.conn = None
-            self._connect()
-
-    def _connect(self):
-        if self.conn:
-            try:
-                self.conn.commit()
-                self.conn.close()
-            except Exception:
-                pass
-        if self.config['host']:
-            # TCP/IP
-            self.conn = psycopg2.connect(host=self.config['host'], port=self.config['port'], 
-                user=self.config['user'], password=self.config['password'], dbname=self.config['dbname'])
-        else:
-            # local socket
-            self.conn = psycopg2.connect(user=self.config['user'], dbname=self.config['dbname'])
-
-        # Test that our table exists
-        qry = f'SELECT 1 FROM {self.name} LIMIT 1'
-        with self._cursor(internal=False) as cursor:    
-            try:
-                cursor.execute(qry)
-            except psycopg2.errors.UndefinedTable:
-                # No such table, build it.
-                print(f"Building cache table {self.name}...")
-                self.conn.rollback()
-                self._make_table()
-
-    def _make_table(self):
-        qry = f"""CREATE TABLE public.{self.name} (
-            {self.pk_defn}   
-            insert_time timestamp without time zone,
-            record_time timestamp without time zone,
-            refresh_time timestamp without time zone,
-            valid boolean,
-            change VARCHAR,
-            data jsonb NOT NULL);"""        
-
-        # Create an index on PK and insert time
-        # idxQry = f"""CREATE INDEX {self.name}_id_idx ON {self.name} ( {self.key} ASC NULLS LAST )"""
-        # This is made by default as _PKEY ; no need to make it manually
-
-        idxQry2 = f"""CREATE INDEX {self.name}_time_idx ON {self.name} ( insert_time  DESC NULLS LAST )"""
-
-        with self._cursor(internal=False) as cursor:
-            try:
-                cursor.execute(qry)
-                cursor.execute(idxQry2)
-                self.conn.commit()
-            except Exception as e:
-                print(f"Make table failed: {e}")
-                self.conn.rollback()
-
-    def _cursor(self, internal=True, is_iter=False):
-        # Ensure cursor is managed server-side otherwise select * from table
-        # will return EVERYTHING into python (without a manual LIMIT/OFFSET)
-
-        if internal:
-            # ensure uniqueness across multiple instances of the code
-            name = f"server_cursor_{self.name}_{time.time()}".replace('.', '_')
-            cursor = self.conn.cursor(name=name, cursor_factory=RealDictCursor)
-            cursor.itersize = self.config['cursor_size']
-        else:
-            # Need this for creating the tables/indexes
-            cursor = self.conn.cursor(cursor_factory=RealDictCursor)
-
-        if is_iter:
-            self.iterating_conn = self.conn
-            self.conn = None
-            self._connect()
-
-        return cursor
-
-    def _close(self, conn=None, is_iter=False):
-        if is_iter:
-            self.iterating_conn.close()
-            self.iterating_conn = None
-
-    def len(self):
-        qry = f"SELECT COUNT(*) FROM {self.name}"
-        with self._cursor(internal=False) as cursor:
-            cursor.execute(qry)
-            res = cursor.fetchone()
-        self._close()
-        return res['count']
-
-
-    def latest(self):
-        qry = f"SELECT insert_time FROM {self.name} ORDER BY insert_time DESC LIMIT 1"
-        with self._cursor() as cursor:
-            cursor.execute(qry)
-            res = cursor.fetchone()
-        self._close()
-        if res:
-            return res['insert_time'].isoformat()
-        else:
-            return "0000-01-01T00:00:00"
-
-    def len_estimate(self):
-        qry = f"SELECT (reltuples/relpages) * (pg_relation_size('{self.name}') \
-        / (current_setting('block_size')::integer)) AS count FROM pg_class WHERE relname='{self.name}';"
-        with self._cursor(internal=False) as cursor:
-            try:
-                cursor.execute(qry)
-                res = cursor.fetchone()        
-            except:
-                # print(f"Called len_estimate, didn't get any hits, rolling back")
-                self.conn.rollback()
-                res = {'count':0}
-        self._close()
-        return int(res['count'])
-
-    def get(self, key, _key_type=None):
-        # Get a record either by YUID or internal identifier,
-        if _key_type is None:
-            _key_type = self.key
-        if _key_type == 'yuid' and len(key) != 36:
-            print(f"{self.name} has UUIDs as keys")
-            return None
-
-        qry = f"SELECT * FROM {self.name} WHERE {_key_type} = %s"
-        params = (key,)
-        cursor = self._cursor(internal=False)
-        cursor.execute(qry, params)
-        rows = cursor.fetchone()
-        cursor.close()        
-        self.conn.commit()
-        self._close()
-        if rows:
-            rows['source'] = self.config['name']
-
-        # sys.stdout.write('G');sys.stdout.flush()
-        return rows
-
-    def get_like(self, key, _key_type=None):
-        # Get a record either by YUID or internal identifier,
-        if _key_type is None:
-            _key_type = self.key
-        if _key_type == 'yuid' and len(key) != 36:
-            print(f"{self.name} has UUIDs as keys")
-            return None
-
-        # ORDER BY here is in case we have multiple copies from different times
-        # We want the most recent
-        qry = f"SELECT * FROM {self.name} WHERE {_key_type} LIKE %s"
-        params = (key + "%",)
-        cursor = self._cursor(internal=False)
-        cursor.execute(qry, params)
-        rows = cursor.fetchone()
-        cursor.close()        
-        self.conn.commit()
-        self._close()
-        if rows:
-            rows['source'] = self.config['name']
-        return rows
-
-
-    def list(self, timestamp=None):
-        # List records changed since timestamp
-        # cast timestamp into datetime it not already
-        # FIXME: This should really be an iterator that pages through
-        if timestamp is None:
-            qry = f"SELECT {self.key} FROM {self.name}"
-            params = []
-        else:
-            qry = f"SELECT {self.key} FROM {self.name} WHERE insert_time >= %s"
-            params = (timestamp,)
-        with self._cursor() as cursor:
-            cursor.execute(qry, params)
-            rows = cursor.fetchall()
-        self._close()
-        return [x[self.key] for x in rows]
-
-    # SELECT t.* FROM (SELECT *, row_number() OVER 
-    #   (ORDER BY identifier ASC) AS row FROM ycba_data_cache) 
-    #   t WHERE t.row % 10 = 1 LIMIT 10
-
-    def iter_records_slice(self, mySlice=0, maxSlice=10):
-        # use row_number() to partition the results into slices for parallel processing
-        if mySlice >= maxSlice:
-            raise ValueError(f"{mySlice} cannot be > {maxSlice}")
-
-        qry = f"""SELECT t.* FROM (SELECT *, row_number() OVER (ORDER BY {self.key} ASC) 
-            AS row FROM {self.name}) t WHERE t.row % {maxSlice} = {mySlice}"""
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry)            
-            for res in cursor:
-                yield res  
-        self._close(is_iter=True)
-
-    def iter_keys_slice(self, mySlice=0, maxSlice=10):
-        # use row_number() to partition the results into slices for parallel processing
-        if mySlice >= maxSlice:
-            raise ValueError(f"{mySlice} cannot be > {maxSlice}")
-
-        qry = f"""SELECT {self.key} FROM (SELECT {self.key}, row_number() OVER (ORDER BY {self.key} ASC) 
-            AS row FROM {self.name}) t WHERE t.row % {maxSlice} = {mySlice}"""
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry)            
-            for res in cursor:
-                yield res[self.key]
-        self._close(is_iter=True)
-
-    def iter_keys_since(self, timestamp=None):
-        if timestamp is None:
-            qry = f"SELECT {self.key} FROM {self.name} ORDER BY insert_time DESC"
-            params = []
-        else:
-            qry = f"SELECT {self.key} FROM {self.name} WHERE record_time >= %s ORDER BY insert_time DESC"        
-            params = (timestamp,)
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry, params)            
-            for res in cursor:
-                yield res[self.key]
-        self._close(is_iter=True)
-
-    def iter_records_since(self, timestamp=None):
-        if timestamp is None:
-            qry = f"SELECT * FROM {self.name} ORDER BY insert_time DESC"
-            params = []
-        else:
-            qry = f"SELECT * FROM {self.name} WHERE record_time >= %s ORDER BY insert_time DESC"        
-            params = (timestamp,)
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry, params)            
-            for res in cursor:
-                yield res        
-        self._close(is_iter=True)
-
-    def iter_records(self):
-        qry = f"SELECT * FROM {self.name}"        
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry)            
-            for res in cursor:
-                yield res 
-        self._close(is_iter=True)
-
-    def iter_keys(self):
-        qry = f"SELECT {self.key} FROM {self.name}"        
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry)            
-            for res in cursor:
-                yield res[self.key]     
-        self._close(is_iter=True)
-
-    def iter_records_type(self, t):
-        # allow query for records by top level type value
-        # CREATE INDEX merged_type_idx ON merged_merged_record_cache USING BTREE ((data->'type'));
-        # is important!
-        qry = f"SELECT * FROM {self.name} WHERE data->'type' = '\"{t}\"'"
-        with self._cursor(iter=True) as cursor:
-            cursor.execute(qry)            
-            for res in cursor:
-                yield res     
-        self._close(is_iter=True)
-
-    def set(self, data, identifier=None, yuid=None, format=None, valid=None,
-            record_time=None, refresh_time=None, change=None):
-        if not identifier and not yuid:
-            raise ValueError("Must give YUID or Identifier or both")
-        if not type(data) == dict:
-            raise ValueError("Data must be a dict()")
-        else:
-            jdata = Json(data)
-        if yuid is not None and not type(yuid) == str:
-            yuid = str(yuid)
-
-        insert_time = datetime.datetime.now()
-        if record_time is None:
-            record_time = insert_time
-        if refresh_time is None:
-            refresh_time = "9999-12-31T00:00:00Z"
-        if format is None:
-            format = "JSON-LD"
-
-        qnames  = ['data', 'identifier', 'yuid', 'insert_time', 'record_time', 'refresh_time', 'valid', 'change']
-        qvals = (jdata, identifier, yuid, insert_time, record_time, refresh_time, valid, change)            
-        qd = dict(zip(qnames, qvals))
-        qps = [qn for qn in qnames if qd[qn] is not None]
-        qvs = tuple([qv for qv in qvals if qv is not None])
-        pholders = ",".join(["%s"] * len(qps))
-        qpstr = ",".join(qps)
-
-        cursor = self._cursor(internal=False)
-        if self.config['overwrite']:
-            try:
-                qry = f"""INSERT INTO {self.name} ({qpstr}) VALUES ({pholders})
-                ON CONFLICT ({self.key}) DO UPDATE SET ({qpstr}) = ({pholders})"""
-                cursor.execute(qry, qvs*2)
-                self.conn.commit()
-            except Exception as e:
-                # Could be a psycopg2.errors.UniqueViolation if we're trying to insert without delete
-                print(f"DATA: {data}")
-                print(f"Failed to upsert!: {e}?\n{qpstr} = {qvs}")
-                self.conn.rollback()                
-        else:
-            try:
-                qry = f"INSERT INTO {self.name} ({qpstr}) VALUES ({pholders})"
-                cursor.execute(qry, qvs)
-                self.conn.commit()
-            except Exception as e:
-                # Could be a psycopg2.errors.UniqueViolation if we're trying to insert without delete
-                print(f"Duplicate key for {identifier}/{yuid} in {self.name}: {e}?")
-                self.conn.rollback()                
-        cursor.close()
-        # sys.stdout.write('S');sys.stdout.flush()
-        self._close()
-
-    def delete(self, key, _key_type=None):
-        if _key_type is None:
-            _key_type = self.key
-        qry = f"DELETE FROM {self.name} WHERE {_key_type} = %s"
-        params = (key,)
-        with self._cursor(internal=False) as cursor:            
-            cursor.execute(qry, params)
-            self.conn.commit()
-        self._close()
-
-    def clear(self):
-        # WARNING WARNING ... trash all the data in the cache
-        qry = f"TRUNCATE TABLE {self.name} RESTART IDENTITY"
-        with self._cursor(internal=False) as cursor:
-            cursor.execute(qry)
-            self.conn.commit()
-        self._close()
-
-    def has_item(self, key, _key_type=None, timestamp=None):
-        if _key_type is None:
-            _key_type = self.key
-        if timestamp is None:
-            qry = f"SELECT 1 FROM {self.name} WHERE {_key_type} = %s LIMIT 1"
-            params = (key,)
-        else:
-            qry = f"SELECT 1 FROM {self.name} WHERE {_key_type} = %s AND record_time >= %s LIMIT 1"
-            params = (key,timestamp)
-
-        cursor = self._cursor(internal=False)
-        cursor.execute(qry, params)
-        rows = cursor.fetchone()
-        cursor.close()
-        self.conn.commit()
-        self._close()
-        # sys.stdout.write('?');sys.stdout.flush()
-        return bool(rows)
-
-    def commit(self):
-        # We commit after every transaction, so no need
-        pass
-
-    def __getitem__(self, what):
-        return self.get(what)
-
-    def __setitem__(self, what, value):
-        if 'data' in value:
-            # given a full record; DO NOT MUTATE IT
-            d = value['data']
-            params = {}
-            if 'identifier' in value and what != value['identifier']:
-                raise ValueError("Record's identifier value and key given to set are different")
-            for v in ['identifier', 'yuid', 'format', 'valid', 'change', 'record_time']:
-                if v in value:
-                    params[v] = value[v]
-            return self.set(d, **params)
-        else:
-            # given only the json
-            if self.key == 'identifier':
-                return self.set(value, identifier=what)
-            elif self.key == 'yuid':
-                return self.set(value, yuid=what)
-
-    def __delitem__(self, what):
-        return self.delete(what)
-
-    def __contains__(self, what):
-        return self.has_item(what)
-
-    def __len__(self):
-        return self.len()
-
-    def __bool__(self):
-        # Don't let it go through to len
-        # and warn that the code shouldn't do this
-        print(f"*** code somewhere is asking for a cache as a boolean value and shouldn't ***")
-        return True
-
-class PooledCache(PGCache):
 
     def __init__(self, config):
         self.config = config
@@ -518,35 +90,13 @@ class PooledCache(PGCache):
                 print(f"Making cache table {self.name}")
                 self.conn.rollback()
                 self._make_table()
-        # This will either close, or return to pool
-        self._close()
-
-
-    def _connect(self):
-        self.conn = poolman.get_conn(self.pool_name)
 
     def shutdown(self):
         # Close our connections
-        if self.conn is not None:
-            self.conn.close()
-            poolman.put_conn(self.pool_name, self.conn)
-        if self.iterating_conn is not None:
-            self.iterating_conn.close()
-            poolman.put_conn(self.pool_name, self.iterating_conn)            
-
-    def _close(self, conn=None, is_iter=False):
-        return None
-
-        if conn is None and is_iter == False:
-            poolman.put_conn(self.pool_name, self.conn)
-            self.conn = None
-        elif is_iter:
-            poolman.put_conn(self.pool_name, self.iterating_conn)
-            self.iterating_conn = None
-        elif conn is not None:
-            poolman.put_conn(self.pool_name, conn)
-
-
+        poolman.put_all(self.pool_name)
+        self.conn = None
+        self.iterating_conn = None
+           
     def _cursor(self, internal=True, iter=False):
         # Ensure cursor is managed server-side otherwise select * from table
         # will return EVERYTHING into python (without a manual LIMIT/OFFSET)
@@ -573,40 +123,280 @@ class PooledCache(PGCache):
 
         return cursor
 
-        # if not self.conn:
-        #     self.conn = poolman.get_conn(self.pool_name, itr=iter)
-
-        # if internal:
-        #     # ensure uniqueness across multiple instances of the code
-        #     name = f"server_cursor_{self.name}_{time.time()}".replace('.', '_')
-        #     cursor = self.conn.cursor(name=name, cursor_factory=RealDictCursor)
-        #     cursor.itersize = self.config['cursor_size']
-        # else:
-        #     # Need this for creating the tables/indexes
-        #     cursor = self.conn.cursor(cursor_factory=RealDictCursor)
-
-        # if is_iter:
-        #     self.iterating_conn = self.conn
-        #     self.conn = None
-        #     self._connect()
-
-        # return cursor
+    # --- pgcache ---
 
 
+    def _make_table(self):
+        qry = f"""CREATE TABLE public.{self.name} (
+            {self.pk_defn}   
+            insert_time timestamp without time zone,
+            record_time timestamp without time zone,
+            refresh_time timestamp without time zone,
+            valid boolean,
+            change VARCHAR,
+            data jsonb NOT NULL);"""        
 
-    def optimize(self):
-        # Call VACUUM on the table
-        qry = f"VACUUM (ANALYZE) {self.name}"
+        # Enable iteration based on insert_time
+        idxQry = f"""CREATE INDEX {self.name}_time_idx ON {self.name} ( insert_time  DESC NULLS LAST )"""
 
-        if not self.conn:
-            self.conn = poolman.get_conn(self.pool_name)
-        old_iso = self.conn.isolation_level
-        self.conn.set_isolation_level(0)
+        with self._cursor(internal=False) as cursor:
+            try:
+                cursor.execute(qry)
+                cursor.execute(idxQry)
+                self.conn.commit()
+            except Exception as e:
+                print(f"Make table failed: {e}")
+                self.conn.rollback()
+
+    def len(self):
+        qry = f"SELECT COUNT(*) FROM {self.name}"
+        with self._cursor(internal=False) as cursor:
+            cursor.execute(qry)
+            res = cursor.fetchone()
+        return res['count']
+
+
+    def latest(self):
+        qry = f"SELECT insert_time FROM {self.name} ORDER BY insert_time DESC LIMIT 1"
+        with self._cursor() as cursor:
+            cursor.execute(qry)
+            res = cursor.fetchone()
+        if res:
+            return res['insert_time'].isoformat()
+        else:
+            return "0000-01-01T00:00:00"
+
+    def len_estimate(self):
+        qry = f"SELECT (reltuples/relpages) * (pg_relation_size('{self.name}') \
+        / (current_setting('block_size')::integer)) AS count FROM pg_class WHERE relname='{self.name}';"
+        with self._cursor(internal=False) as cursor:
+            try:
+                cursor.execute(qry)
+                res = cursor.fetchone()        
+            except:
+                # print(f"Called len_estimate, didn't get any hits, rolling back")
+                self.conn.rollback()
+                res = {'count':0}
+        return int(res['count'])
+
+    def get(self, key, _key_type=None):
+        # Get a record either by YUID or internal identifier,
+        if _key_type is None:
+            _key_type = self.key
+        if _key_type == 'yuid' and len(key) != 36:
+            print(f"{self.name} has UUIDs as keys")
+            return None
+
+        qry = f"SELECT * FROM {self.name} WHERE {_key_type} = %s"
+        params = (key,)
+        with self._cursor(internal=False) as cursor:
+            cursor.execute(qry, params)
+            rows = cursor.fetchone()     
+        self.conn.commit()
+        if rows:
+            rows['source'] = self.config['name']
+        # sys.stdout.write('G');sys.stdout.flush()
+        return rows
+
+    def get_like(self, key, _key_type=None):
+        # Get a record either by YUID or internal identifier,
+        if _key_type is None:
+            _key_type = self.key
+        if _key_type == 'yuid' and len(key) != 36:
+            print(f"{self.name} has UUIDs as keys")
+            return None
+
+        # ORDER BY here is in case we have multiple copies from different times
+        # We want the most recent
+        qry = f"SELECT * FROM {self.name} WHERE {_key_type} LIKE %s"
+        params = (key + "%",)
+        with self._cursor(internal=False) as cursor:
+            cursor.execute(qry, params)
+            rows = cursor.fetchone()     
+        self.conn.commit()
+        if rows:
+            rows['source'] = self.config['name']
+        return rows
+
+    def list(self, timestamp=None):
+        # List records changed since timestamp
+        # cast timestamp into datetime it not already
+        # FIXME: This should really be an iterator that pages through
+        if timestamp is None:
+            qry = f"SELECT {self.key} FROM {self.name}"
+            params = []
+        else:
+            qry = f"SELECT {self.key} FROM {self.name} WHERE insert_time >= %s"
+            params = (timestamp,)
+        with self._cursor() as cursor:
+            cursor.execute(qry, params)
+            rows = cursor.fetchall()
+        return [x[self.key] for x in rows]
+
+    # SELECT t.* FROM (SELECT *, row_number() OVER 
+    #   (ORDER BY identifier ASC) AS row FROM ycba_data_cache) 
+    #   t WHERE t.row % 10 = 1 LIMIT 10
+
+    def iter_records_slice(self, mySlice=0, maxSlice=10):
+        # use row_number() to partition the results into slices for parallel processing
+        if mySlice >= maxSlice:
+            raise ValueError(f"{mySlice} cannot be > {maxSlice}")
+
+        qry = f"""SELECT t.* FROM (SELECT *, row_number() OVER (ORDER BY {self.key} ASC) 
+            AS row FROM {self.name}) t WHERE t.row % {maxSlice} = {mySlice}"""
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry)            
+            for res in cursor:
+                yield res          
+
+    def iter_keys_slice(self, mySlice=0, maxSlice=10):
+        # use row_number() to partition the results into slices for parallel processing
+        if mySlice >= maxSlice:
+            raise ValueError(f"{mySlice} cannot be > {maxSlice}")
+
+        qry = f"""SELECT {self.key} FROM (SELECT {self.key}, row_number() OVER (ORDER BY {self.key} ASC) 
+            AS row FROM {self.name}) t WHERE t.row % {maxSlice} = {mySlice}"""
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry)            
+            for res in cursor:
+                yield res[self.key]
+
+    def iter_keys_since(self, timestamp=None):
+        if timestamp is None:
+            qry = f"SELECT {self.key} FROM {self.name} ORDER BY insert_time DESC"
+            params = []
+        else:
+            qry = f"SELECT {self.key} FROM {self.name} WHERE record_time >= %s ORDER BY insert_time DESC"        
+            params = (timestamp,)
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry, params)            
+            for res in cursor:
+                yield res[self.key]
+
+    def iter_records_since(self, timestamp=None):
+        if timestamp is None:
+            qry = f"SELECT * FROM {self.name} ORDER BY insert_time DESC"
+            params = []
+        else:
+            qry = f"SELECT * FROM {self.name} WHERE record_time >= %s ORDER BY insert_time DESC"        
+            params = (timestamp,)
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry, params)            
+            for res in cursor:
+                yield res        
+
+    def iter_records(self):
+        qry = f"SELECT * FROM {self.name}"        
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry)            
+            for res in cursor:
+                yield res 
+
+    def iter_keys(self):
+        qry = f"SELECT {self.key} FROM {self.name}"        
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry)            
+            for res in cursor:
+                yield res[self.key]     
+
+    def iter_records_type(self, t):
+        # allow query for records by top level type value
+        # CREATE INDEX merged_type_idx ON merged_merged_record_cache USING BTREE ((data->'type'));
+        # is important!
+        qry = f"SELECT * FROM {self.name} WHERE data->'type' = '\"{t}\"'"
+        with self._cursor(iter=True) as cursor:
+            cursor.execute(qry)            
+            for res in cursor:
+                yield res     
+
+    def set(self, data, identifier=None, yuid=None, format=None, valid=None,
+            record_time=None, refresh_time=None, change=None):
+        if not identifier and not yuid:
+            raise ValueError("Must give YUID or Identifier or both")
+        if not type(data) == dict:
+            raise ValueError("Data must be a dict()")
+        else:
+            jdata = Json(data)
+        if yuid is not None and not type(yuid) == str:
+            yuid = str(yuid)
+
+        insert_time = datetime.datetime.now()
+        if record_time is None:
+            record_time = insert_time
+        if refresh_time is None:
+            refresh_time = "9999-12-31T00:00:00Z"
+        if format is None:
+            format = "JSON-LD"
+
+        qnames  = ['data', 'identifier', 'yuid', 'insert_time', 'record_time', 'refresh_time', 'valid', 'change']
+        qvals = (jdata, identifier, yuid, insert_time, record_time, refresh_time, valid, change)            
+        qd = dict(zip(qnames, qvals))
+        qps = [qn for qn in qnames if qd[qn] is not None]
+        qvs = tuple([qv for qv in qvals if qv is not None])
+        pholders = ",".join(["%s"] * len(qps))
+        qpstr = ",".join(qps)
+
+        with self._cursor(internal=False) as cursor:
+            if self.config['overwrite']:
+                try:
+                    qry = f"""INSERT INTO {self.name} ({qpstr}) VALUES ({pholders})
+                    ON CONFLICT ({self.key}) DO UPDATE SET ({qpstr}) = ({pholders})"""
+                    cursor.execute(qry, qvs*2)
+                    self.conn.commit()
+                except Exception as e:
+                    # Could be a psycopg2.errors.UniqueViolation if we're trying to insert without delete
+                    print(f"DATA: {data}")
+                    print(f"Failed to upsert!: {e}?\n{qpstr} = {qvs}")
+                    self.conn.rollback()                
+            else:
+                try:
+                    qry = f"INSERT INTO {self.name} ({qpstr}) VALUES ({pholders})"
+                    cursor.execute(qry, qvs)
+                    self.conn.commit()
+                except Exception as e:
+                    # Could be a psycopg2.errors.UniqueViolation if we're trying to insert without delete
+                    print(f"Duplicate key for {identifier}/{yuid} in {self.name}: {e}?")
+                    self.conn.rollback()                
+        # sys.stdout.write('S');sys.stdout.flush()
+
+
+    def delete(self, key, _key_type=None):
+        if _key_type is None:
+            _key_type = self.key
+        qry = f"DELETE FROM {self.name} WHERE {_key_type} = %s"
+        params = (key,)
+        with self._cursor(internal=False) as cursor:            
+            cursor.execute(qry, params)
+            self.conn.commit()
+
+    def clear(self):
+        # WARNING WARNING ... trash all the data in the cache
+        qry = f"TRUNCATE TABLE {self.name} RESTART IDENTITY"
         with self._cursor(internal=False) as cursor:
             cursor.execute(qry)
             self.conn.commit()
-        self.conn.set_isolation_level(old_iso)
-        self._close()
+
+    def has_item(self, key, _key_type=None, timestamp=None):
+        if _key_type is None:
+            _key_type = self.key
+        if timestamp is None:
+            qry = f"SELECT 1 FROM {self.name} WHERE {_key_type} = %s LIMIT 1"
+            params = (key,)
+        else:
+            qry = f"SELECT 1 FROM {self.name} WHERE {_key_type} = %s AND record_time >= %s LIMIT 1"
+            params = (key,timestamp)
+
+        with self._cursor(internal=False) as cursor:
+            cursor.execute(qry, params)
+            rows = cursor.fetchone()
+
+        self.conn.commit()
+        # sys.stdout.write('?');sys.stdout.flush()
+        return bool(rows)
+
+    def commit(self):
+        # We commit after every transaction, so no need
+        pass
 
     def start_bulk(self):
         self.bulk_conn = poolman.get_conn(self.pool_name)        
@@ -647,6 +437,56 @@ class PooledCache(PGCache):
         self.bulk_cursor = None
         poolman.put_conn(self.pool_name, self.bulk_conn)
         self.bulk_conn = None
+
+    def optimize(self):
+        # Call VACUUM on the table
+        qry = f"VACUUM (ANALYZE) {self.name}"
+
+        if not self.conn:
+            self.conn = poolman.get_conn(self.pool_name)
+        old_iso = self.conn.isolation_level
+        self.conn.set_isolation_level(0)
+        with self._cursor(internal=False) as cursor:
+            cursor.execute(qry)
+            self.conn.commit()
+        self.conn.set_isolation_level(old_iso)
+
+
+    def __getitem__(self, what):
+        return self.get(what)
+
+    def __setitem__(self, what, value):
+        if 'data' in value:
+            # given a full record; DO NOT MUTATE IT
+            d = value['data']
+            params = {}
+            if 'identifier' in value and what != value['identifier']:
+                raise ValueError("Record's identifier value and key given to set are different")
+            for v in ['identifier', 'yuid', 'format', 'valid', 'change', 'record_time']:
+                if v in value:
+                    params[v] = value[v]
+            return self.set(d, **params)
+        else:
+            # given only the json
+            if self.key == 'identifier':
+                return self.set(value, identifier=what)
+            elif self.key == 'yuid':
+                return self.set(value, yuid=what)
+
+    def __delitem__(self, what):
+        return self.delete(what)
+
+    def __contains__(self, what):
+        return self.has_item(what)
+
+    def __len__(self):
+        return self.len()
+
+    def __bool__(self):
+        # Don't let it go through to len
+        # and warn that the code shouldn't do this
+        print(f"*** code somewhere is asking for a cache as a boolean value and shouldn't ***")
+        return True
 
 
 class DataCache(PooledCache):

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -492,8 +492,8 @@ class PooledCache(PGCache):
 
 
     def _connect(self):
+        print(f"{self.name} requesting connection")
         self.conn = poolman.get_conn(self.pool_name)
-
 
     def shutdown(self):
         # Close our connections
@@ -503,7 +503,6 @@ class PooledCache(PGCache):
         if self.iterating_conn is not None:
             self.iterating_conn.close()
             poolman.put_conn(self.pool_name, self.iterating_conn)            
-
 
     def _close(self, conn=None, is_iter=False):
         if conn is None and is_iter == False:

--- a/pipeline/storage/idmap/redis.py
+++ b/pipeline/storage/idmap/redis.py
@@ -441,6 +441,8 @@ class TransitiveMultiMap(MultiMap):
 
 
 class RedisDictValue(object):
+    ### NOTE WELL: This is just a reference into redis
+    ### NOT a copy of the information from redis
 
     def __init__(self, key, refmap):
         self.persistence = refmap

--- a/run-reconcile.py
+++ b/run-reconcile.py
@@ -130,6 +130,7 @@ if profiling:
     pr.disable()
     s = io.StringIO()
     sortby = SortKey.CUMULATIVE
+    # sortby = SortKey.TIME
     ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
     ps.print_stats()
     print(s.getvalue())

--- a/run-reconcile.py
+++ b/run-reconcile.py
@@ -8,6 +8,11 @@ from pipeline.process.reconciler import Reconciler
 from pipeline.process.reference_manager import ReferenceManager
 from pipeline.storage.cache.postgres import poolman
 
+import io
+import cProfile
+import pstats
+from pstats import SortKey
+
 load_dotenv()
 basepath = os.getenv('LUX_BASEPATH', "")
 cfgs = Config(basepath=basepath)
@@ -21,6 +26,12 @@ cfgs.instantiate_all()
 my_slice = -1
 max_slice = -1
  
+if '--profile' in sys.argv:
+    sys.argv.remove('--profile')
+    profiling = True
+else:
+    profiling = False
+
 # NOTE: This implies the existence and use of AAT
 if '--baseline' in sys.argv:
     # Only do global terms. Only needed with a new idmap
@@ -59,12 +70,19 @@ else:
     to_do = [x[0] for x in s_to_do]
 
 
+
+
+
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 ref_mgr = ReferenceManager(cfgs, idmap)
 debug = cfgs.debug_reconciliation
 
 print("Starting...")
+
+if profiling:
+    pr = cProfile.Profile()
+    pr.enable()
 
 for name, cfg in to_do:
     print(f" *** {name} ***")
@@ -106,6 +124,16 @@ for name, cfg in to_do:
             ref_mgr.manage_identifiers(rec, rebuild=True)
 
     recids = []
+
+
+if profiling:
+    pr.disable()
+    s = io.StringIO()
+    sortby = SortKey.CUMULATIVE
+    ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+    ps.print_stats()
+    print(s.getvalue())
+    raise ValueError()
 
 # now do references
 


### PR DESCRIPTION
This PR cuts reconciliation time by approximately 50%.

* Faster escape for valid ISO8601 dates
* Only use two connections to postgres (one for get/set, one for iterate) and consolidate implementation to single class
* Don't do missing death date test (*very* slow in sqlite)
* In-process cache before redis for AAT referenced records
* Enable profiling in run-reconcile with `--profile` on the command line