### PR TITLE
Dnb web fix

### DIFF
--- a/pipeline/sources/libraries/dnb/mapper.py
+++ b/pipeline/sources/libraries/dnb/mapper.py
@@ -360,9 +360,9 @@ class DnbMapper(Mapper):
             lo = model.LinguisticObject(label="Website Text")
             do = vocab.WebPage(label="Home Page")            
             do.access_point = model.DigitalObject(ident=val['@id'])
-            matchnumber = val['@id'].split('/')[-1]
+            matchnumber = val['@id'].split('/')
             recnumber = rec['@id'].split('/')[-1]
-            if matchnumber == recnumber:
+            if recnumber in matchnumber:
                 continue
             lo.digitally_carried_by = do
             top.subject_of = lo
@@ -457,9 +457,9 @@ class DnbMapper(Mapper):
             if type(hp) != list:
                 hp = [hp]
             for h in hp:
-                matchnumber = h.split('/')[-1]
+                matchnumber = h.split('/')
                 recnumber = rec['@id'].split('/')[-1]
-                if matchnumber == recnumber:
+                if recnumber in matchnumber:
                     continue
                 # make homepage ref
                 lo = model.LinguisticObject(label="Website Text")


### PR DESCRIPTION
DNB webpages can often end in "about"

regardless of what other weirdness they might contain, splitting the webpage ident on "/" and checking if recnumber is in that list should allow the tossing out of matches to work.

example rec:
https://lux-front-tst.collections.yale.edu/view/group/948f4f29-00cf-4534-a162-a1650a888a59

(ignore other weirdness about that rec, i.e. that it's a Group called "music", working on that elsewhere...)