### PR TITLE
updated occupation flag AAT to 300263369

### DIFF
--- a/pipeline/sources/authorities/getty/mapper.py
+++ b/pipeline/sources/authorities/getty/mapper.py
@@ -36,7 +36,7 @@ class GettyMapper(Mapper):
 
         self.gender_flag = "http://vocab.getty.edu/aat/300055147"
         self.nationality_flag = "http://vocab.getty.edu/aat/300379842"
-        self.occupation_flag = "http://vocab.getty.edu/aat/300435108"
+        self.occupation_flag = "http://vocab.getty.edu/aat/300263369"
         self.active_flag = "http://vocab.getty.edu/aat/300393177"
 
         self.aat_language_ids = [x.id for x in self.process_langs.values()]


### PR DESCRIPTION
Getty seems to have changed the AAT from roles > occupations, which is good and more correct
updated our mapper to use the new meta-classification AAT