### PR TITLE
Debug recon

### DIFF
--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -136,11 +136,11 @@ plt.figure(figsize=(12, 12))
 node_color_values = ['skyblue' for _ in G.nodes()]  
 node_labels = {node: node for node in G.nodes()} 
 edge_color_values = ['black' for _ in G.edges()] 
-pos = nx.spring_layout(G)
+pos = nx.spring_layout(G, k=0.15)
 
 nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
-edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values, node_size=150)
-nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=16)
+edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=12)
 
 # Add a legend
 plt.legend([nodes, edges], ['Nodes', 'Edges'])

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -122,4 +122,7 @@ for sets in list(nx.connected_components(G)):
 print(f"\nPath from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
+print("\nLongest Path:")
+longest_path = nx.dag_longest_path(G)
+print(" --> ".join([inv_ident[x] for x in longest_path]))
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -54,17 +54,7 @@ uris = idmap[yuid]
 
 names = {}
 
-for u in uris:
-    if u.startswith('__'):
-        continue
-    (base, qua) = cfgs.split_qua(u)
-    (src, ident) = cfgs.split_uri(base)
-    idents[base] = f"{src['name']}:{curr}"
-    curr = chr(ord(curr)+1)
-    rec = src['acquirer'].acquire(ident)
-    if not rec:
-        print(f"Couldn't acquire {src['name']}:{ident}")
-        continue
+def append_to_graph(cfgs, src, base, curr, idents, names, rec):
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
     if 'equivalent' in rec['data']:
@@ -89,30 +79,20 @@ for u in uris:
                 except:
                     graph[base] = [eq['id']]
 
+for u in uris:
+    if u.startswith('__'):
+        continue
+    (base, qua) = cfgs.split_qua(u)
+    (src, ident) = cfgs.split_uri(base)
+    idents[base] = f"{src['name']}:{curr}"
+    curr = chr(ord(curr)+1)
+    rec = src['acquirer'].acquire(ident)
+    if not rec:
+        print(f"Couldn't acquire {src['name']}:{ident}")
+        continue
+    append_to_graph(cfgs, src, base, curr, idents, rec)
     rec2 = reconciler.reconcile(rec)
-    if '_label' in rec2['data']:
-        names[base] = rec2['data']['_label']
-    if 'equivalent' in rec2['data']:
-        for eq in rec2['data']['equivalent']:
-            if 'id' in eq:
-                eqid = eq['id']
-                if not eqid in idents:
-                    try:
-                        (eqsrc, eqident) = cfgs.split_uri(eqid)
-                        idents[eqid] = f"{src['name']}:{curr}"
-                        if not eqid in names:
-                            ref = src['mapper'].get_reference(eqident)
-                            if hasattr(ref, '_label'):
-                                names[eqid] = ref._label
-                            else:
-                                names[eqid] = "-no label-"
-                        curr = chr(ord(curr)+1)
-                    except:
-                        idents[eqid] = eqid
-                try:
-                    graph[base].append(eq['id'])
-                except:
-                    graph[base] = [eq['id']]
+    append_to_graph(cfgs, src, base, curr, idents, rec2)
 
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))
@@ -139,9 +119,9 @@ for (k,v) in idents.items():
     inv_ident[v] = k
 
 key.sort()
-#print("  -- Key --")
-#for k in key:
-#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+print("  -- Key --")
+for k in key:
+   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
 print("\nConnected Nodes:")
 for sets in list(nx.connected_components(G)):
@@ -150,26 +130,26 @@ for sets in list(nx.connected_components(G)):
 print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
-# print("\nLongest Path:")
-# longest_path = []
-# for node in G.nodes:
-#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-#         if len(path) > len(longest_path):
-#             longest_path = path
-# print(" --> ".join([inv_ident[x] for x in longest_path]))
+print("\nLongest Path:")
+longest_path = []
+for node in G.nodes:
+    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+        if len(path) > len(longest_path):
+            longest_path = path
+print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
-# plt.figure(figsize=(12, 12))
-# node_color_values = ['skyblue' for _ in G.nodes()]  
-# node_labels = {node: node for node in G.nodes()} 
-# edge_color_values = ['black' for _ in G.edges()] 
-# pos = nx.spring_layout(G, k=1)
+plt.figure(figsize=(12, 12))
+node_color_values = ['skyblue' for _ in G.nodes()]  
+node_labels = {node: node for node in G.nodes()} 
+edge_color_values = ['black' for _ in G.edges()] 
+pos = nx.spring_layout(G, k=1)
 
-# nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
-# edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
-# nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
-# #plt.legend([nodes, edges], ['Nodes', 'Edges'])
+#plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-# plt.savefig("graph.png")
-#plt.show(block=True) 
+plt.savefig("graph.png")
+plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -89,16 +89,17 @@ for u in uris:
                 #well actually it doesn't, because it has the wrong yuid. does that matter?
                 if not eqid in idents:
                     # print(f"eqid {eqid} not in idents from uri {u}")
-                    try:
+                    try:                        
+                        curr = chr(ord(curr)+1)
                         (eqsrc, eqident) = cfgs.split_uri(eqid)
-                        idents[eqid] = f"{src['name']}:{curr}"
+                        #definitely it needs to be eqsrc below
+                        idents[eqid] = f"{eqsrc['name']}:{curr}"
                         if not eqid in names:
                             ref = src['mapper'].get_reference(eqident)
                             if hasattr(ref, '_label'):
                                 names[eqid] = ref._label
                             else:
                                 names[eqid] = "-no label-"
-                        curr = chr(ord(curr)+1)
                     except:
                         idents[eqid] = eqid
                 try:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -131,14 +131,9 @@ for node in G.nodes:
             longest_path = path
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
-# Draw the graph
-nx.draw(G, with_labels=True, node_color='skyblue', node_size=500, edge_color='white')
 
-# Add edge labels
-edge_labels = nx.get_edge_attributes(G, 'weight')  # replace 'weight' with the name of the attribute
-nx.draw_networkx_edge_labels(G, pos=nx.spring_layout(G), edge_labels=edge_labels)
-
-# Show the plot
+pos = nx.circular_layout(G)
+nx.draw(G, pos=pos, with_labels=True, node_color='skyblue', node_size=500, edge_color='white')
 plt.savefig("graph.png")
 plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,7 +132,7 @@ for node in G.nodes:
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
-pos = nx.circular_layout(G)
+pos = nx.spring_layout(G)
 nx.draw(G, pos=pos, with_labels=True, node_color='skyblue', node_size=500, edge_color='white')
 plt.savefig("graph.png")
 plt.show()

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -64,12 +64,13 @@ for u in uris:
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
-    # rec = src['acquirer'].acquire(ident)
-    # if not rec:
-    #     #print(f"Couldn't acquire {src['name']}:{ident}")
-    #     continue
-    # if '_label' in rec['data']:
-    #     names[base] = rec['data']['_label']
+    rec = src['acquirer'].acquire(ident)
+    if not rec:
+        print(f"Couldn't acquire {src['name']}:{ident}")
+        continue
+    #working right until this point
+    if '_label' in rec['data']:
+        names[base] = rec['data']['_label']
     # if 'equivalent' in rec['data']:
     #     for eq in rec['data']['equivalent']:
     #         if 'id' in eq:
@@ -92,7 +93,7 @@ for u in uris:
     #             except:
     #                 graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-for k, v in idents.items():
+for k, v in names.items():
     print(f"{k}:{v}\n-------------")
 # G = nx.Graph()
 # G.add_nodes_from(list(idents.values()))

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -142,8 +142,6 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
-# for k, v in inv_ident.items():
-#     print(f"{k}:{v}\n-------------")
 
 key.sort()
 print("  -- Key --")
@@ -157,26 +155,26 @@ for sets in list(nx.connected_components(G)):
 print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
-# print("\nLongest Path:")
-# longest_path = []
-# for node in G.nodes:
-#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-#         if len(path) > len(longest_path):
-#             longest_path = path
-# print(" --> ".join([inv_ident[x] for x in longest_path]))
+print("\nLongest Path:")
+longest_path = []
+for node in G.nodes:
+    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+        if len(path) > len(longest_path):
+            longest_path = path
+print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
-# plt.figure(figsize=(12, 12))
-# node_color_values = ['skyblue' for _ in G.nodes()]  
-# node_labels = {node: node for node in G.nodes()} 
-# edge_color_values = ['black' for _ in G.edges()] 
-# pos = nx.spring_layout(G, k=1)
+plt.figure(figsize=(12, 12))
+node_color_values = ['skyblue' for _ in G.nodes()]  
+node_labels = {node: node for node in G.nodes()} 
+edge_color_values = ['black' for _ in G.edges()] 
+pos = nx.spring_layout(G, k=1)
 
-# nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
-# edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
-# nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
-# #plt.legend([nodes, edges], ['Nodes', 'Edges'])
+#plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-# plt.savefig("graph.png")
-# plt.show(block=True) 
+plt.savefig("graph.png")
+plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,8 +132,9 @@ for node in G.nodes:
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
+plt.figure(figsize=(12, 12))
 pos = nx.spring_layout(G)
-nx.draw(G, pos=pos, with_labels=True, node_color='skyblue', node_size=500, edge_color='white')
+nx.draw(G, pos=pos, with_labels=True, node_color='skyblue', node_size=500, font_size=16, edge_color='white')
 plt.savefig("graph.png")
 plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -90,7 +90,6 @@ for u in uris:
                     graph[base] = [eq['id']]
 
     rec2 = reconciler.reconcile(rec)
-    print(f"rec2 is {rec2}")
     if '_label' in rec2['data']:
         names[base] = rec2['data']['_label']
     if 'equivalent' in rec2['data']:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -107,8 +107,8 @@ for u in uris:
                 except:
                     graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-# for k, v in idents.items():
-#     print(f"{k}:{v}\n-------------")
+for k, v in idents.items():
+    print(f"{k}:{v}\n-------------")
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))
 
@@ -132,8 +132,8 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
-for k, v in inv_ident.items():
-    print(f"{k}:{v}\n-------------")
+# for k, v in inv_ident.items():
+#     print(f"{k}:{v}\n-------------")
 
 # key.sort()
 # print("  -- Key --")
@@ -145,7 +145,7 @@ for k, v in inv_ident.items():
 #     print(sets)
 
 # print(f"\nShortest path from {from_p} to {to_p}")
-# print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+# print(" --> ".join([inv_ident[http://www.wikidata.org/entity/Q3709888x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 # print("\nLongest Path:")
 # longest_path = []

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -133,8 +133,17 @@ print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
 plt.figure(figsize=(12, 12))
-pos = nx.spring_layout(G)
-nx.draw(G, pos=pos, with_labels=True, node_color='skyblue', node_size=500, font_size=16, edge_color='white')
+node_color_values = ['skyblue' for _ in G.nodes()]  
+node_labels = {node: node for node in G.nodes()} 
+edge_color_values = ['white' for _ in G.edges()] 
+
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=500)
+edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=16)
+
+# Add a legend
+plt.legend([nodes, edges], ['Nodes', 'Edges'])
+
+# Save the plot to a file
 plt.savefig("graph.png")
-plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -51,6 +51,7 @@ idents = {}
 graph = {}
 
 uris = idmap[yuid]
+print(f"uris are {uris}")
 
 names = {}
 
@@ -77,7 +78,7 @@ for u in uris:
                 eqid = eq['id']
                 #why does it do this block at all? it already has everything that makes up the record
                 if not eqid in idents:
-                    print(f"eqid {eqid} not in idents from uri {u}")
+                    # print(f"eqid {eqid} not in idents from uri {u}")
                     try:
                         (eqsrc, eqident) = cfgs.split_uri(eqid)
                         idents[eqid] = f"{src['name']}:{curr}"

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -63,62 +63,64 @@ for u in uris:
     (src, ident) = cfgs.split_uri(base)
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
-    print(f"idents is {idents}\n----------")
-    curr = chr(ord(curr)+1)
-    rec = src['acquirer'].acquire(ident)
-    if not rec:
-        #print(f"Couldn't acquire {src['name']}:{ident}")
-        continue
-    if '_label' in rec['data']:
-        names[base] = rec['data']['_label']
-    if 'equivalent' in rec['data']:
-        for eq in rec['data']['equivalent']:
-            if 'id' in eq:
-                eqid = eq['id']
-                if not eqid in idents:
-                    try:
-                        (eqsrc, eqident) = cfgs.split_uri(eqid)
-                        idents[eqid] = f"{src['name']}:{curr}"
-                        if not eqid in names:
-                            ref = src['mapper'].get_reference(eqident)
-                            if hasattr(ref, '_label'):
-                                names[eqid] = ref._label
-                            else:
-                                names[eqid] = "-no label-"
-                        curr = chr(ord(curr)+1)
-                    except:
-                        idents[eqid] = eqid
-                try:
-                    graph[base].append(eq['id'])
-                except:
-                    graph[base] = [eq['id']]
+    print(f"idents is:")
+    for k, v in idents.items():
+        print(f"{key}:{value}\n-------------")
+    # curr = chr(ord(curr)+1)
+    # rec = src['acquirer'].acquire(ident)
+    # if not rec:
+    #     #print(f"Couldn't acquire {src['name']}:{ident}")
+    #     continue
+    # if '_label' in rec['data']:
+    #     names[base] = rec['data']['_label']
+    # if 'equivalent' in rec['data']:
+    #     for eq in rec['data']['equivalent']:
+    #         if 'id' in eq:
+    #             eqid = eq['id']
+    #             if not eqid in idents:
+    #                 try:
+    #                     (eqsrc, eqident) = cfgs.split_uri(eqid)
+    #                     idents[eqid] = f"{src['name']}:{curr}"
+    #                     if not eqid in names:
+    #                         ref = src['mapper'].get_reference(eqident)
+    #                         if hasattr(ref, '_label'):
+    #                             names[eqid] = ref._label
+    #                         else:
+    #                             names[eqid] = "-no label-"
+    #                     curr = chr(ord(curr)+1)
+    #                 except:
+    #                     idents[eqid] = eqid
+    #             try:
+    #                 graph[base].append(eq['id'])
+    #             except:
+    #                 graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
 
-G = nx.Graph()
-G.add_nodes_from(list(idents.values()))
+# G = nx.Graph()
+# G.add_nodes_from(list(idents.values()))
 
-new_graph = {}
-for (k,v) in graph.items():
-    subj = idents[k]
-    l = []
-    for u in v:
-        if u in idents:
-            obj = idents[u]
-            l.append(obj)
-            G.add_edge(subj, obj)
-        else:
-            pass
-    l.sort()
-    new_graph[subj] = l
+# new_graph = {}
+# for (k,v) in graph.items():
+#     subj = idents[k]
+#     l = []
+#     for u in v:
+#         if u in idents:
+#             obj = idents[u]
+#             l.append(obj)
+#             G.add_edge(subj, obj)
+#         else:
+#             pass
+#     l.sort()
+#     new_graph[subj] = l
 
 
-key = []
-inv_ident = {}
-for (k,v) in idents.items():
-    key.append((v, k))
-    inv_ident[v] = k
+# key = []
+# inv_ident = {}
+# for (k,v) in idents.items():
+#     key.append((v, k))
+#     inv_ident[v] = k
 
-key.sort()
+# key.sort()
 # print("  -- Key --")
 # for k in key:
 #    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -25,30 +25,31 @@ cfgs.instantiate_all()
 from_p = sys.argv[1]
 to_p = sys.argv[2]
 
-print(f"from p is {from_p}")
-print(f"to p is {to_p}")
+# print(f"from p is {from_p}")
+# print(f"to p is {to_p}")
 
 try:
     (src, ident) = cfgs.split_uri(from_p)
-    print(f"line 33 src is {src}")
-    print(f"line 33 ident is {ident}")
+    # print(f"line 33 src is {src}")
+    # print(f"line 33 ident is {ident}")
 except:
-    print(f"Unknown URI: {from_p}")
+    # print(f"Unknown URI: {from_p}")
     sys.exit()
 try:
     ref = src['mapper'].get_reference(ident)
-    print(f"ref is {ref}")
+    #get reference returns the wrong type, so it grabs the wrong yuid
+    #print(f"ref is {ref}")
     base = cfgs.canonicalize(from_p)
-    print(f"base is {base}")
+    #print(f"base is {base}")
     qua = cfgs.make_qua(base, ref.type)
-    print(f"qua is {qua}")
+    #print(f"qua is {qua}")
 except:
     print(f"Could not make typed URI for {from_p}")
     raise
     sys.exit()
 
 yuid = idmap[qua]
-print(f"yuid is {yuid}")
+#print(f"yuid is {yuid}")
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
@@ -80,12 +81,12 @@ for u in uris:
         continue
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
-    #working right until this point
     if 'equivalent' in rec['data']:
         for eq in rec['data']['equivalent']:
             if 'id' in eq:
                 eqid = eq['id']
                 #why does it do this block at all? it already has everything that makes up the record
+                #well actually it doesn't, because it has the wrong yuid. does that matter?
                 if not eqid in idents:
                     # print(f"eqid {eqid} not in idents from uri {u}")
                     try:
@@ -105,8 +106,8 @@ for u in uris:
                 except:
                     graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-# for k, v in names.items():
-#     print(f"{k}:{v}\n-------------")
+for k, v in idents.items():
+    print(f"{k}:{v}\n-------------")
 # G = nx.Graph()
 # G.add_nodes_from(list(idents.values()))
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -63,9 +63,6 @@ for u in uris:
     (src, ident) = cfgs.split_uri(base)
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
-    print(f"idents is:")
-    for k, v in idents.items():
-        print(f"{k}:{v}\n-------------")
     # curr = chr(ord(curr)+1)
     # rec = src['acquirer'].acquire(ident)
     # if not rec:
@@ -95,7 +92,8 @@ for u in uris:
     #             except:
     #                 graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-
+for k, v in idents.items():
+    print(f"{k}:{v}\n-------------")
 # G = nx.Graph()
 # G.add_nodes_from(list(idents.values()))
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -59,8 +59,9 @@ for u in uris:
     if u.startswith('__'):
         continue
     (base, qua) = cfgs.split_qua(u)
-    print(f"base and qua are {base}/{qua}\n----------")
+    #print(f"base and qua are {base}/{qua}\n----------")
     (src, ident) = cfgs.split_uri(base)
+    print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
     rec = src['acquirer'].acquire(ident)

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -107,43 +107,43 @@ for u in uris:
                 except:
                     graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-for k, v in idents.items():
-    print(f"{k}:{v}\n-------------")
-# G = nx.Graph()
-# G.add_nodes_from(list(idents.values()))
+# for k, v in idents.items():
+#     print(f"{k}:{v}\n-------------")
+G = nx.Graph()
+G.add_nodes_from(list(idents.values()))
 
-# new_graph = {}
-# for (k,v) in graph.items():
-#     subj = idents[k]
-#     l = []
-#     for u in v:
-#         if u in idents:
-#             obj = idents[u]
-#             l.append(obj)
-#             G.add_edge(subj, obj)
-#         else:
-#             pass
-#     l.sort()
-#     new_graph[subj] = l
+new_graph = {}
+for (k,v) in graph.items():
+    subj = idents[k]
+    l = []
+    for u in v:
+        if u in idents:
+            obj = idents[u]
+            l.append(obj)
+            G.add_edge(subj, obj)
+        else:
+            pass
+    l.sort()
+    new_graph[subj] = l
 
 
-# key = []
-# inv_ident = {}
-# for (k,v) in idents.items():
-#     key.append((v, k))
-#     inv_ident[v] = k
+key = []
+inv_ident = {}
+for (k,v) in idents.items():
+    key.append((v, k))
+    inv_ident[v] = k
 
-# key.sort()
-# print("  -- Key --")
-# for k in key:
-#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+key.sort()
+print("  -- Key --")
+for k in key:
+   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
-# print("\nConnected Nodes:")
-# for sets in list(nx.connected_components(G)):
-#     print(sets)
+print("\nConnected Nodes:")
+for sets in list(nx.connected_components(G)):
+    print(sets)
 
-# print(f"\nShortest path from {from_p} to {to_p}")
-# print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+print(f"\nShortest path from {from_p} to {to_p}")
+print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 # print("\nLongest Path:")
 # longest_path = []

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -90,6 +90,7 @@ for u in uris:
                     graph[base] = [eq['id']]
 
     rec2 = reconciler.reconcile(rec)
+    print(f"rec2 is {rec2}")
     if '_label' in rec2['data']:
         names[base] = rec2['data']['_label']
     if 'equivalent' in rec2['data']:
@@ -139,9 +140,9 @@ for (k,v) in idents.items():
     inv_ident[v] = k
 
 key.sort()
-print("  -- Key --")
-for k in key:
-    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+#print("  -- Key --")
+#for k in key:
+#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
 print("\nConnected Nodes:")
 for sets in list(nx.connected_components(G)):
@@ -159,17 +160,17 @@ print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], id
 # print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
-plt.figure(figsize=(12, 12))
-node_color_values = ['skyblue' for _ in G.nodes()]  
-node_labels = {node: node for node in G.nodes()} 
-edge_color_values = ['black' for _ in G.edges()] 
-pos = nx.spring_layout(G, k=1)
+# plt.figure(figsize=(12, 12))
+# node_color_values = ['skyblue' for _ in G.nodes()]  
+# node_labels = {node: node for node in G.nodes()} 
+# edge_color_values = ['black' for _ in G.edges()] 
+# pos = nx.spring_layout(G, k=1)
 
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
-edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
-nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
+# nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+# edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+# nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
-#plt.legend([nodes, edges], ['Nodes', 'Edges'])
+# #plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-plt.savefig("graph.png")
+# plt.savefig("graph.png")
 #plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -150,13 +150,13 @@ for sets in list(nx.connected_components(G)):
 print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
-print("\nLongest Path:")
-longest_path = []
-for node in G.nodes:
-    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-        if len(path) > len(longest_path):
-            longest_path = path
-print(" --> ".join([inv_ident[x] for x in longest_path]))
+# print("\nLongest Path:")
+# longest_path = []
+# for node in G.nodes:
+#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+#         if len(path) > len(longest_path):
+#             longest_path = path
+# print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
 plt.figure(figsize=(12, 12))

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -7,7 +7,7 @@ from pipeline.config import Config
 from pipeline.process.reconciler import Reconciler
 from pipeline.process.reference_manager import ReferenceManager
 from pipeline.storage.cache.postgres import poolman
-
+import matplotlib.pyplot as plt
 import networkx as nx
 
 load_dotenv()
@@ -130,9 +130,6 @@ for node in G.nodes:
             longest_path = path
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
-try:
-    cycle = nx.find_cycle(G, orientation='original')
-    print("Cycle found:", cycle)
-except nx.NetworkXNoCycle:
-    print("No cycle found.")
+nx.draw(G, with_labels=True, node_color='skyblue', node_size=1500, edge_color='white')
+plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -75,63 +75,64 @@ for u in uris:
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
+    print(f"acquiring {ident}")
     rec = src['acquirer'].acquire(ident)
     if not rec:
         print(f"Couldn't acquire {src['name']}:{ident}")
         continue
-    if '_label' in rec['data']:
-        names[base] = rec['data']['_label']
-    if 'equivalent' in rec['data']:
-        for eq in rec['data']['equivalent']:
-            if 'id' in eq:
-                eqid = eq['id']
-                #why does it do this block at all? it already has everything that makes up the record
-                #well actually it doesn't, because it has the wrong yuid. does that matter?
-                if not eqid in idents:
-                    # print(f"eqid {eqid} not in idents from uri {u}")
-                    try:                        
-                        curr = chr(ord(curr)+1)
-                        (eqsrc, eqident) = cfgs.split_uri(eqid)
-                        #definitely it needs to be eqsrc below
-                        idents[eqid] = f"{eqsrc['name']}:{curr}"
-                        if not eqid in names:
-                            ref = src['mapper'].get_reference(eqident)
-                            if hasattr(ref, '_label'):
-                                names[eqid] = ref._label
-                            else:
-                                names[eqid] = "-no label-"
-                    except:
-                        idents[eqid] = eqid
-                try:
-                    graph[base].append(eq['id'])
-                except:
-                    graph[base] = [eq['id']]
+    # if '_label' in rec['data']:
+    #     names[base] = rec['data']['_label']
+    # if 'equivalent' in rec['data']:
+    #     for eq in rec['data']['equivalent']:
+    #         if 'id' in eq:
+    #             eqid = eq['id']
+    #             #why does it do this block at all? it already has everything that makes up the record
+    #             #well actually it doesn't, because it has the wrong yuid. does that matter?
+    #             if not eqid in idents:
+    #                 # print(f"eqid {eqid} not in idents from uri {u}")
+    #                 try:                        
+    #                     curr = chr(ord(curr)+1)
+    #                     (eqsrc, eqident) = cfgs.split_uri(eqid)
+    #                     #definitely it needs to be eqsrc below
+    #                     idents[eqid] = f"{eqsrc['name']}:{curr}"
+    #                     if not eqid in names:
+    #                         ref = src['mapper'].get_reference(eqident)
+    #                         if hasattr(ref, '_label'):
+    #                             names[eqid] = ref._label
+    #                         else:
+    #                             names[eqid] = "-no label-"
+    #                 except:
+    #                     idents[eqid] = eqid
+    #             try:
+    #                 graph[base].append(eq['id'])
+    #             except:
+    #                 graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-for k, v in idents.items():
-    print(f"{k}:{v}\n-------------")
-G = nx.Graph()
-G.add_nodes_from(list(idents.values()))
+# for k, v in idents.items():
+#     print(f"{k}:{v}\n-------------")
+# G = nx.Graph()
+# G.add_nodes_from(list(idents.values()))
 
-new_graph = {}
-for (k,v) in graph.items():
-    subj = idents[k]
-    l = []
-    for u in v:
-        if u in idents:
-            obj = idents[u]
-            l.append(obj)
-            G.add_edge(subj, obj)
-        else:
-            pass
-    l.sort()
-    new_graph[subj] = l
+# new_graph = {}
+# for (k,v) in graph.items():
+#     subj = idents[k]
+#     l = []
+#     for u in v:
+#         if u in idents:
+#             obj = idents[u]
+#             l.append(obj)
+#             G.add_edge(subj, obj)
+#         else:
+#             pass
+#     l.sort()
+#     new_graph[subj] = l
 
 
-key = []
-inv_ident = {}
-for (k,v) in idents.items():
-    key.append((v, k))
-    inv_ident[v] = k
+# key = []
+# inv_ident = {}
+# for (k,v) in idents.items():
+#     key.append((v, k))
+#     inv_ident[v] = k
 # for k, v in inv_ident.items():
 #     print(f"{k}:{v}\n-------------")
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -123,7 +123,7 @@ print(f"\nPath from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 print("\nLongest Path:")
-g = nx.DiGraph(G)
+G = nx.DiGraph(G)
 longest_path = nx.dag_longest_path(G)
 print(" --> ".join([inv_ident[x] for x in longest_path]))
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -119,7 +119,7 @@ print("\nConnected Nodes:")
 for sets in list(nx.connected_components(G)):
     print(sets)
 
-print(f"\nPath from {from_p} to {to_p}")
+print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 print("\nLongest Path:")
@@ -129,4 +129,10 @@ for node in G.nodes:
         if len(path) > len(longest_path):
             longest_path = path
 print(" --> ".join([inv_ident[x] for x in longest_path]))
+
+try:
+    cycle = nx.find_cycle(G, orientation='original')
+    print("Cycle found:", cycle)
+except nx.NetworkXNoCycle:
+    print("No cycle found.")
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -136,7 +136,7 @@ plt.figure(figsize=(12, 12))
 node_color_values = ['skyblue' for _ in G.nodes()]  
 node_labels = {node: node for node in G.nodes()} 
 edge_color_values = ['black' for _ in G.edges()] 
-pos = nx.spring_layout(G, k=0.15)
+pos = nx.spring_layout(G, k=1)
 
 nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -136,6 +136,7 @@ plt.figure(figsize=(12, 12))
 node_color_values = ['skyblue' for _ in G.nodes()]  
 node_labels = {node: node for node in G.nodes()} 
 edge_color_values = ['white' for _ in G.edges()] 
+pos = nx.spring_layout(G)
 
 nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=500)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -54,7 +54,18 @@ uris = idmap[yuid]
 
 names = {}
 
-def append_to_graph(cfgs, src, base, idents, rec):
+
+for u in uris:
+    if u.startswith('__'):
+        continue
+    (base, qua) = cfgs.split_qua(u)
+    (src, ident) = cfgs.split_uri(base)
+    idents[base] = f"{src['name']}:{curr}"
+    curr = chr(ord(curr)+1)
+    rec = src['acquirer'].acquire(ident)
+    if not rec:
+        print(f"Couldn't acquire {src['name']}:{ident}")
+        continue
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
     if 'equivalent' in rec['data']:
@@ -78,21 +89,7 @@ def append_to_graph(cfgs, src, base, idents, rec):
                     graph[base].append(eq['id'])
                 except:
                     graph[base] = [eq['id']]
-
-for u in uris:
-    if u.startswith('__'):
-        continue
-    (base, qua) = cfgs.split_qua(u)
-    (src, ident) = cfgs.split_uri(base)
-    idents[base] = f"{src['name']}:{curr}"
-    curr = chr(ord(curr)+1)
-    rec = src['acquirer'].acquire(ident)
-    if not rec:
-        print(f"Couldn't acquire {src['name']}:{ident}")
-        continue
-    append_to_graph(cfgs, src, base, idents, rec)
-    rec2 = reconciler.reconcile(rec)
-    append_to_graph(cfgs, src, base, idents, rec2)
+    #rec2 = reconciler.reconcile(rec)
 
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -61,8 +61,9 @@ for u in uris:
     (base, qua) = cfgs.split_qua(u)
     #print(f"base and qua are {base}/{qua}\n----------")
     (src, ident) = cfgs.split_uri(base)
-    print(f"src and ident are {src}/{ident}\n----------")
+    #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
+    print(f"idents is {idents}\n----------")
     curr = chr(ord(curr)+1)
     rec = src['acquirer'].acquire(ident)
     if not rec:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -54,7 +54,7 @@ uris = idmap[yuid]
 
 names = {}
 
-def append_to_graph(cfgs, src, base, curr, idents, names, rec):
+def append_to_graph(cfgs, src, base, curr, idents, rec):
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
     if 'equivalent' in rec['data']:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -131,7 +131,14 @@ for node in G.nodes:
             longest_path = path
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
-nx.draw(G, with_labels=True, node_color='skyblue', node_size=1500, edge_color='white')
+# Draw the graph
+nx.draw(G, with_labels=True, node_color='skyblue', node_size=500, edge_color='white')
+
+# Add edge labels
+edge_labels = nx.get_edge_attributes(G, 'weight')  # replace 'weight' with the name of the attribute
+nx.draw_networkx_edge_labels(G, pos=nx.spring_layout(G), edge_labels=edge_labels)
+
+# Show the plot
 plt.savefig("graph.png")
 plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -65,7 +65,7 @@ for u in uris:
     idents[base] = f"{src['name']}:{curr}"
     print(f"idents is:")
     for k, v in idents.items():
-        print(f"{key}:{value}\n-------------")
+        print(f"{k}:{v}\n-------------")
     # curr = chr(ord(curr)+1)
     # rec = src['acquirer'].acquire(ident)
     # if not rec:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -75,78 +75,102 @@ for u in uris:
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
-    print(f"acquiring {ident}")
+    #it's failing because it doesn't have the right yuid--
+    #print(f"acquiring {ident}")
     rec = src['acquirer'].acquire(ident)
     if not rec:
         print(f"Couldn't acquire {src['name']}:{ident}")
         continue
-    # if '_label' in rec['data']:
-    #     names[base] = rec['data']['_label']
-    # if 'equivalent' in rec['data']:
-    #     for eq in rec['data']['equivalent']:
-    #         if 'id' in eq:
-    #             eqid = eq['id']
-    #             #why does it do this block at all? it already has everything that makes up the record
-    #             #well actually it doesn't, because it has the wrong yuid. does that matter?
-    #             if not eqid in idents:
-    #                 # print(f"eqid {eqid} not in idents from uri {u}")
-    #                 try:                        
-    #                     curr = chr(ord(curr)+1)
-    #                     (eqsrc, eqident) = cfgs.split_uri(eqid)
-    #                     #definitely it needs to be eqsrc below
-    #                     idents[eqid] = f"{eqsrc['name']}:{curr}"
-    #                     if not eqid in names:
-    #                         ref = src['mapper'].get_reference(eqident)
-    #                         if hasattr(ref, '_label'):
-    #                             names[eqid] = ref._label
-    #                         else:
-    #                             names[eqid] = "-no label-"
-    #                 except:
-    #                     idents[eqid] = eqid
-    #             try:
-    #                 graph[base].append(eq['id'])
-    #             except:
-    #                 graph[base] = [eq['id']]
-    #rec2 = reconciler.reconcile(rec)
+    if '_label' in rec['data']:
+        names[base] = rec['data']['_label']
+    if 'equivalent' in rec['data']:
+        for eq in rec['data']['equivalent']:
+            if 'id' in eq:
+                eqid = eq['id']
+                #why does it do this block at all? it already has everything that makes up the record
+                #well actually it doesn't, because it has the wrong yuid. does that matter?
+                if not eqid in idents:
+                    # print(f"eqid {eqid} not in idents from uri {u}")
+                    try:                        
+                        curr = chr(ord(curr)+1)
+                        (eqsrc, eqident) = cfgs.split_uri(eqid)
+                        #definitely it needs to be eqsrc below
+                        idents[eqid] = f"{eqsrc['name']}:{curr}"
+                        if not eqid in names:
+                            ref = src['mapper'].get_reference(eqident)
+                            if hasattr(ref, '_label'):
+                                names[eqid] = ref._label
+                            else:
+                                names[eqid] = "-no label-"
+                    except:
+                        idents[eqid] = eqid
+                try:
+                    graph[base].append(eq['id'])
+                except:
+                    graph[base] = [eq['id']]
+    rec2 = reconciler.reconcile(rec)
+    if '_label' in rec2['data']:
+        names[base] = rec2['data']['_label']
+    if 'equivalent' in rec2['data']:
+        for eq in rec2['data']['equivalent']:
+            if 'id' in eq:
+                eqid = eq['id']
+                if not eqid in idents:
+                    try:                        
+                        curr = chr(ord(curr)+1)
+                        (eqsrc, eqident) = cfgs.split_uri(eqid)
+                        idents[eqid] = f"{eqsrc['name']}:{curr}"
+                        if not eqid in names:
+                            ref = src['mapper'].get_reference(eqident)
+                            if hasattr(ref, '_label'):
+                                names[eqid] = ref._label
+                            else:
+                                names[eqid] = "-no label-"
+                    except:
+                        idents[eqid] = eqid
+                try:
+                    graph[base].append(eq['id'])
+                except:
+                    graph[base] = [eq['id']]
 # for k, v in idents.items():
 #     print(f"{k}:{v}\n-------------")
-# G = nx.Graph()
-# G.add_nodes_from(list(idents.values()))
+G = nx.Graph()
+G.add_nodes_from(list(idents.values()))
 
-# new_graph = {}
-# for (k,v) in graph.items():
-#     subj = idents[k]
-#     l = []
-#     for u in v:
-#         if u in idents:
-#             obj = idents[u]
-#             l.append(obj)
-#             G.add_edge(subj, obj)
-#         else:
-#             pass
-#     l.sort()
-#     new_graph[subj] = l
+new_graph = {}
+for (k,v) in graph.items():
+    subj = idents[k]
+    l = []
+    for u in v:
+        if u in idents:
+            obj = idents[u]
+            l.append(obj)
+            G.add_edge(subj, obj)
+        else:
+            pass
+    l.sort()
+    new_graph[subj] = l
 
 
-# key = []
-# inv_ident = {}
-# for (k,v) in idents.items():
-#     key.append((v, k))
-#     inv_ident[v] = k
+key = []
+inv_ident = {}
+for (k,v) in idents.items():
+    key.append((v, k))
+    inv_ident[v] = k
 # for k, v in inv_ident.items():
 #     print(f"{k}:{v}\n-------------")
 
-# key.sort()
-# print("  -- Key --")
-# for k in key:
-#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+key.sort()
+print("  -- Key --")
+for k in key:
+   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
-# print("\nConnected Nodes:")
-# for sets in list(nx.connected_components(G)):
-#     print(sets)
+print("\nConnected Nodes:")
+for sets in list(nx.connected_components(G)):
+    print(sets)
 
-# print(f"\nShortest path from {from_p} to {to_p}")
-# print(" --> ".join([inv_ident[http://www.wikidata.org/entity/Q3709888x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+print(f"\nShortest path from {from_p} to {to_p}")
+print(" --> ".join([inv_ident[http://www.wikidata.org/entity/Q3709888x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 # print("\nLongest Path:")
 # longest_path = []

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -87,6 +87,7 @@ for u in uris:
                 except:
                     graph[base] = [eq['id']]
 
+
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))
 
@@ -140,11 +141,9 @@ pos = nx.spring_layout(G, k=1)
 
 nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
-nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=12)
+nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
-# Add a legend
 plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-# Save the plot to a file
-plt.savefig("graph.png")
- 
+#plt.savefig("graph.png")
+plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -135,11 +135,11 @@ print(" --> ".join([inv_ident[x] for x in longest_path]))
 plt.figure(figsize=(12, 12))
 node_color_values = ['skyblue' for _ in G.nodes()]  
 node_labels = {node: node for node in G.nodes()} 
-edge_color_values = ['white' for _ in G.edges()] 
+edge_color_values = ['black' for _ in G.edges()] 
 pos = nx.spring_layout(G)
 
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=500)
-edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values, node_size=150)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=16)
 
 # Add a legend

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,18 +132,19 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
+print(f"inv index is {inv index}")
 
-key.sort()
-print("  -- Key --")
-for k in key:
-   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+# key.sort()
+# print("  -- Key --")
+# for k in key:
+#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
-print("\nConnected Nodes:")
-for sets in list(nx.connected_components(G)):
-    print(sets)
+# print("\nConnected Nodes:")
+# for sets in list(nx.connected_components(G)):
+#     print(sets)
 
-print(f"\nShortest path from {from_p} to {to_p}")
-print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+# print(f"\nShortest path from {from_p} to {to_p}")
+# print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 # print("\nLongest Path:")
 # longest_path = []

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -7,6 +7,8 @@ from pipeline.config import Config
 from pipeline.process.reconciler import Reconciler
 from pipeline.process.reference_manager import ReferenceManager
 from pipeline.storage.cache.postgres import poolman
+import matplotlib
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 import networkx as nx
 
@@ -131,5 +133,6 @@ for node in G.nodes:
 print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 nx.draw(G, with_labels=True, node_color='skyblue', node_size=1500, edge_color='white')
+plt.savefig("graph.png")
 plt.show()
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -63,7 +63,7 @@ for u in uris:
     (src, ident) = cfgs.split_uri(base)
     #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
-    # curr = chr(ord(curr)+1)
+    curr = chr(ord(curr)+1)
     # rec = src['acquirer'].acquire(ident)
     # if not rec:
     #     #print(f"Couldn't acquire {src['name']}:{ident}")

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,7 +132,7 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
-print(f"inv index is {inv index}")
+print(f"inv index is {inv_index}")
 
 # key.sort()
 # print("  -- Key --")

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -38,8 +38,9 @@ except:
     print(f"Could not make typed URI for {from_p}")
     raise
     sys.exit()
-yuid = idmap[qua]
 
+yuid = idmap[qua]
+print(f"yuid is {yuid}")
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
@@ -51,7 +52,7 @@ idents = {}
 graph = {}
 
 uris = idmap[yuid]
-print(f"uris are {uris}")
+# print(f"uris are {uris}")
 
 names = {}
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -68,33 +68,35 @@ for u in uris:
     if not rec:
         print(f"Couldn't acquire {src['name']}:{ident}")
         continue
-    #working right until this point
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
-    # if 'equivalent' in rec['data']:
-    #     for eq in rec['data']['equivalent']:
-    #         if 'id' in eq:
-    #             eqid = eq['id']
-    #             if not eqid in idents:
-    #                 try:
-    #                     (eqsrc, eqident) = cfgs.split_uri(eqid)
-    #                     idents[eqid] = f"{src['name']}:{curr}"
-    #                     if not eqid in names:
-    #                         ref = src['mapper'].get_reference(eqident)
-    #                         if hasattr(ref, '_label'):
-    #                             names[eqid] = ref._label
-    #                         else:
-    #                             names[eqid] = "-no label-"
-    #                     curr = chr(ord(curr)+1)
-    #                 except:
-    #                     idents[eqid] = eqid
-    #             try:
-    #                 graph[base].append(eq['id'])
-    #             except:
-    #                 graph[base] = [eq['id']]
+    #working right until this point
+    if 'equivalent' in rec['data']:
+        for eq in rec['data']['equivalent']:
+            if 'id' in eq:
+                eqid = eq['id']
+                #why does it do this block at all? it already has everything that makes up the record
+                if not eqid in idents:
+                    print(f"eqid {eqid} not in idents from uri {u}")
+                    try:
+                        (eqsrc, eqident) = cfgs.split_uri(eqid)
+                        idents[eqid] = f"{src['name']}:{curr}"
+                        if not eqid in names:
+                            ref = src['mapper'].get_reference(eqident)
+                            if hasattr(ref, '_label'):
+                                names[eqid] = ref._label
+                            else:
+                                names[eqid] = "-no label-"
+                        curr = chr(ord(curr)+1)
+                    except:
+                        idents[eqid] = eqid
+                try:
+                    graph[base].append(eq['id'])
+                except:
+                    graph[base] = [eq['id']]
     #rec2 = reconciler.reconcile(rec)
-for k, v in names.items():
-    print(f"{k}:{v}\n-------------")
+# for k, v in names.items():
+#     print(f"{k}:{v}\n-------------")
 # G = nx.Graph()
 # G.add_nodes_from(list(idents.values()))
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -123,6 +123,7 @@ print(f"\nPath from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 print("\nLongest Path:")
+g = nx.DiGraph(G)
 longest_path = nx.dag_longest_path(G)
 print(" --> ".join([inv_ident[x] for x in longest_path]))
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -54,7 +54,7 @@ uris = idmap[yuid]
 
 names = {}
 
-def append_to_graph(cfgs, src, base, curr, idents, rec):
+def append_to_graph(cfgs, src, base, idents, rec):
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
     if 'equivalent' in rec['data']:
@@ -90,9 +90,9 @@ for u in uris:
     if not rec:
         print(f"Couldn't acquire {src['name']}:{ident}")
         continue
-    append_to_graph(cfgs, src, base, curr, idents, rec)
+    append_to_graph(cfgs, src, base, idents, rec)
     rec2 = reconciler.reconcile(rec)
-    append_to_graph(cfgs, src, base, curr, idents, rec2)
+    append_to_graph(cfgs, src, base, idents, rec2)
 
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -25,31 +25,23 @@ cfgs.instantiate_all()
 from_p = sys.argv[1]
 to_p = sys.argv[2]
 
-# print(f"from p is {from_p}")
-# print(f"to p is {to_p}")
 
 try:
     (src, ident) = cfgs.split_uri(from_p)
-    # print(f"line 33 src is {src}")
-    # print(f"line 33 ident is {ident}")
 except:
-    # print(f"Unknown URI: {from_p}")
+    print(f"Unknown URI: {from_p}")
     sys.exit()
 try:
     ref = src['mapper'].get_reference(ident)
     #get reference returns the wrong type, so it grabs the wrong yuid
-    #print(f"ref is {ref}")
     base = cfgs.canonicalize(from_p)
-    #print(f"base is {base}")
     qua = cfgs.make_qua(base, ref.type)
-    #print(f"qua is {qua}")
 except:
     print(f"Could not make typed URI for {from_p}")
     raise
     sys.exit()
 
 yuid = idmap[qua]
-#print(f"yuid is {yuid}")
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
@@ -61,7 +53,6 @@ idents = {}
 graph = {}
 
 uris = idmap[yuid]
-# print(f"uris are {uris}")
 
 names = {}
 
@@ -70,13 +61,9 @@ for u in uris:
     if u.startswith('__'):
         continue
     (base, qua) = cfgs.split_qua(u)
-    #print(f"base and qua are {base}/{qua}\n----------")
     (src, ident) = cfgs.split_uri(base)
-    #print(f"src and ident are {src}/{ident}\n----------")
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
-    #it's failing because it doesn't have the right yuid--
-    #print(f"acquiring {ident}")
     rec = src['acquirer'].acquire(ident)
     if not rec:
         print(f"Couldn't acquire {src['name']}:{ident}")
@@ -88,9 +75,8 @@ for u in uris:
             if 'id' in eq:
                 eqid = eq['id']
                 #why does it do this block at all? it already has everything that makes up the record
-                #well actually it doesn't, because it has the wrong yuid. does that matter?
+                #well actually it doesn't, because it has the wrong yuid. if it did, would it need this block?
                 if not eqid in idents:
-                    # print(f"eqid {eqid} not in idents from uri {u}")
                     try:                        
                         curr = chr(ord(curr)+1)
                         (eqsrc, eqident) = cfgs.split_uri(eqid)
@@ -132,8 +118,7 @@ for u in uris:
                     graph[base].append(eq['id'])
                 except:
                     graph[base] = [eq['id']]
-# for k, v in idents.items():
-#     print(f"{k}:{v}\n-------------")
+
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -59,12 +59,13 @@ for u in uris:
     if u.startswith('__'):
         continue
     (base, qua) = cfgs.split_qua(u)
+    print(f"base and qua are {base}/{qua}\n----------")
     (src, ident) = cfgs.split_uri(base)
     idents[base] = f"{src['name']}:{curr}"
     curr = chr(ord(curr)+1)
     rec = src['acquirer'].acquire(ident)
     if not rec:
-        print(f"Couldn't acquire {src['name']}:{ident}")
+        #print(f"Couldn't acquire {src['name']}:{ident}")
         continue
     if '_label' in rec['data']:
         names[base] = rec['data']['_label']
@@ -116,37 +117,37 @@ for (k,v) in idents.items():
     inv_ident[v] = k
 
 key.sort()
-print("  -- Key --")
-for k in key:
-   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+# print("  -- Key --")
+# for k in key:
+#    print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
 
-print("\nConnected Nodes:")
-for sets in list(nx.connected_components(G)):
-    print(sets)
+# print("\nConnected Nodes:")
+# for sets in list(nx.connected_components(G)):
+#     print(sets)
 
-print(f"\nShortest path from {from_p} to {to_p}")
-print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+# print(f"\nShortest path from {from_p} to {to_p}")
+# print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
-print("\nLongest Path:")
-longest_path = []
-for node in G.nodes:
-    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-        if len(path) > len(longest_path):
-            longest_path = path
-print(" --> ".join([inv_ident[x] for x in longest_path]))
+# print("\nLongest Path:")
+# longest_path = []
+# for node in G.nodes:
+#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+#         if len(path) > len(longest_path):
+#             longest_path = path
+# print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
-plt.figure(figsize=(12, 12))
-node_color_values = ['skyblue' for _ in G.nodes()]  
-node_labels = {node: node for node in G.nodes()} 
-edge_color_values = ['black' for _ in G.edges()] 
-pos = nx.spring_layout(G, k=1)
+# plt.figure(figsize=(12, 12))
+# node_color_values = ['skyblue' for _ in G.nodes()]  
+# node_labels = {node: node for node in G.nodes()} 
+# edge_color_values = ['black' for _ in G.edges()] 
+# pos = nx.spring_layout(G, k=1)
 
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
-edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
-nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
+# nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+# edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
+# nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
-#plt.legend([nodes, edges], ['Nodes', 'Edges'])
+# #plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-plt.savefig("graph.png")
-plt.show(block=True) 
+# plt.savefig("graph.png")
+# plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,7 +132,7 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
-print(f"inv index is {inv_index}")
+print(f"inv index is {inv_ident}")
 
 # key.sort()
 # print("  -- Key --")

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -145,5 +145,5 @@ nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 
 plt.legend([nodes, edges], ['Nodes', 'Edges'])
 
-#plt.savefig("graph.png")
-plt.show(block=True) 
+plt.savefig("graph.png")
+#plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -155,13 +155,16 @@ for sets in list(nx.connected_components(G)):
 print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
-print("\nLongest Path:")
-longest_path = []
-for node in G.nodes:
-    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-        if len(path) > len(longest_path):
-            longest_path = path
-print(" --> ".join([inv_ident[x] for x in longest_path]))
+
+#this code worked until I introduced reconcile, now it takes WAY too long to compile. 
+#we can't use the DAG function because we have cycles in our graph
+# print("\nLongest Path:")
+# longest_path = []
+# for node in G.nodes:
+#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+#         if len(path) > len(longest_path):
+#             longest_path = path
+# print(" --> ".join([inv_ident[x] for x in longest_path]))
 
 
 plt.figure(figsize=(12, 12))

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -170,7 +170,7 @@ for sets in list(nx.connected_components(G)):
     print(sets)
 
 print(f"\nShortest path from {from_p} to {to_p}")
-print(" --> ".join([inv_ident[http://www.wikidata.org/entity/Q3709888x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
+print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 # print("\nLongest Path:")
 # longest_path = []

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -132,7 +132,8 @@ inv_ident = {}
 for (k,v) in idents.items():
     key.append((v, k))
     inv_ident[v] = k
-print(f"inv index is {inv_ident}")
+for k, v in inv_ident.items():
+    print(f"{k}:{v}\n-------------")
 
 # key.sort()
 # print("  -- Key --")

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -123,7 +123,10 @@ print(f"\nPath from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 print("\nLongest Path:")
-G = nx.DiGraph(G)
-longest_path = nx.dag_longest_path(G)
+longest_path = []
+for node in G.nodes:
+    for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
+        if len(path) > len(longest_path):
+            longest_path = path
 print(" --> ".join([inv_ident[x] for x in longest_path]))
  

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -25,15 +25,23 @@ cfgs.instantiate_all()
 from_p = sys.argv[1]
 to_p = sys.argv[2]
 
+print(f"from p is {from_p}")
+print(f"to p is {to_p}")
+
 try:
     (src, ident) = cfgs.split_uri(from_p)
+    print(f"line 33 src is {src}")
+    print(f"line 33 ident is {ident}")
 except:
     print(f"Unknown URI: {from_p}")
     sys.exit()
 try:
     ref = src['mapper'].get_reference(ident)
+    print(f"ref is {ref}")
     base = cfgs.canonicalize(from_p)
+    print(f"base is {base}")
     qua = cfgs.make_qua(base, ref.type)
+    print(f"qua is {qua}")
 except:
     print(f"Could not make typed URI for {from_p}")
     raise

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -7,8 +7,7 @@ from pipeline.config import Config
 from pipeline.process.reconciler import Reconciler
 from pipeline.process.reference_manager import ReferenceManager
 from pipeline.storage.cache.postgres import poolman
-import matplotlib
-matplotlib.use('TkAgg')
+
 import matplotlib.pyplot as plt
 import networkx as nx
 

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -11,12 +11,10 @@ class Reconciler(object):
         for src in config.external.values():
             rlr = src.get('reconciler', None)
             if rlr:
-                print(f"adding {rlr} to reconcilers")
                 self.reconcilers.append(rlr)
         for src in config.results.values():
             rlr = src.get('reconciler', None)
             if rlr:
-                print(f"adding {rlr} to reconcilers")
                 self.reconcilers.append(rlr)
 
         self.global_reconciler = config.results['merged'].get('reconciler', None)
@@ -121,7 +119,6 @@ class Reconciler(object):
                     # or a list (if the reconciler knows multiple sources,
                     #   or if there's more than one actual match to add from a single source)
                     newids = r.reconcile(record, reconcileType=reconcileType)
-                    print(f"newids are {newids}")
                 except:
                     print(r)
                     raise

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -11,10 +11,12 @@ class Reconciler(object):
         for src in config.external.values():
             rlr = src.get('reconciler', None)
             if rlr:
+                print(f"adding {rlr} to reconcilers")
                 self.reconcilers.append(rlr)
         for src in config.results.values():
             rlr = src.get('reconciler', None)
             if rlr:
+                print(f"adding {rlr} to reconcilers")
                 self.reconcilers.append(rlr)
 
         self.global_reconciler = config.results['merged'].get('reconciler', None)
@@ -119,6 +121,7 @@ class Reconciler(object):
                     # or a list (if the reconciler knows multiple sources,
                     #   or if there's more than one actual match to add from a single source)
                     newids = r.reconcile(record, reconcileType=reconcileType)
+                    print(f"newids are {newids}")
                 except:
                     print(r)
                     raise

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -28,7 +28,6 @@ class GlobalReconciler(LmdbReconciler):
         if type(record) == str:
             ids = [record]
         else:
-            print(f"trying to gets ids from: {record['data']['equivalent']}")
             ids = [x['id'] for x in record['data'].get('equivalent', [])]
             if 'id' in record['data']:
                 ids.append(record['data']['id'])

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -36,19 +36,20 @@ class GlobalReconciler(LmdbReconciler):
                     print(f"No id in {record}")
                     return []
             except:
-                pass
+                ids = None
 
         # Only have a map of uris, no types
         vals = set([])
         idx = self.id_index if reconcileType == "uri" else self.diff_index
-        for eq in ids:
-            try:
-                s = idx[eq]
-            except:
-                continue
-            if s:
-                if type(s) in [set, list]:
-                    vals.update(s)
-                elif type(s) == str:
-                    vals.add(s)
+        if ids:
+            for eq in ids:
+                try:
+                    s = idx[eq]
+                except:
+                    continue
+                if s:
+                    if type(s) in [set, list]:
+                        vals.update(s)
+                    elif type(s) == str:
+                        vals.add(s)
         return vals

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -35,8 +35,9 @@ class GlobalReconciler(LmdbReconciler):
                 else:
                     print(f"No id in {record}")
                     return []
-            except:
-                continue
+            except Exception as {e}:
+                print(e)
+                pass
 
         # Only have a map of uris, no types
         vals = set([])

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -35,8 +35,7 @@ class GlobalReconciler(LmdbReconciler):
                 else:
                     print(f"No id in {record}")
                     return []
-            except Exception as {e}:
-                print(e)
+            except:
                 pass
 
         # Only have a map of uris, no types

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -28,12 +28,15 @@ class GlobalReconciler(LmdbReconciler):
         if type(record) == str:
             ids = [record]
         else:
-            ids = [x['id'] for x in record['data'].get('equivalent', [])]
-            if 'id' in record['data']:
-                ids.append(record['data']['id'])
-            else:
-                print(f"No id in {record}")
-                return []
+            try:
+                ids = [x['id'] for x in record['data'].get('equivalent', [])]
+                if 'id' in record['data']:
+                    ids.append(record['data']['id'])
+                else:
+                    print(f"No id in {record}")
+                    return []
+            except:
+                continue
 
         # Only have a map of uris, no types
         vals = set([])

--- a/pipeline/sources/lux/final/reconciler.py
+++ b/pipeline/sources/lux/final/reconciler.py
@@ -28,6 +28,7 @@ class GlobalReconciler(LmdbReconciler):
         if type(record) == str:
             ids = [record]
         else:
+            print(f"trying to gets ids from: {record['data']['equivalent']}")
             ids = [x['id'] for x in record['data'].get('equivalent', [])]
             if 'id' in record['data']:
                 ids.append(record['data']['id'])


### PR DESCRIPTION
ok, woof, this is complicated.

additions:
final reconciler: it kept failing at line 32 because for some reason x was a string with a bnf record. rather than figure that out, I just added error handling so it would get past it.

debug reconcile: 
1. visualization of the graph, which works, but doesn't display inline (not fully sure why).
2. longest path. we can't use the dag function because there's cycles in our graph--DNB refers to itself prior to any reconciliation, then after reconciliation a lot of things refer to themselves. it's clear in the visualization. so I use this hacky code which works until reconciliation was introduced. after that, it's way too slow/takes far too long to compile. 
3. I added and removed a lot of print statements trying to debug. I messaged you in Teams about what I found. 
4. The one actual bug in this code was at line 84 ish where curr wasn't being updated in the right place, and src was being used where eqsrc should have been. this was assigning "wikidata: ;;" to ror uris, for example.

I am stymied at the reconciliation issues. Going to go work on Wikidata mapper testing we discussed last week which is affecting the very beginning of the script, where get_reference returns the wrong class and such the wrong YUID.


