### PR TITLE
Fast

### DIFF
--- a/manage-data.py
+++ b/manage-data.py
@@ -99,10 +99,6 @@ if '--load' in sys.argv:
         my_slice = int(sys.argv[1])
         max_slice = int(sys.argv[2])
         cfgs.external['wikidata']['loader'].load(my_slice, max_slice)
-    if '--fast' in sys.argv:
-        my_slice = int(sys.argv[1])
-        max_slice = int(sys.argv[2])
-        cfgs.external['fast']['loader'].load(my_slice, max_slice)
 
 ### LOAD INDEXES
 if '--load-index' in sys.argv:

--- a/manage-data.py
+++ b/manage-data.py
@@ -99,10 +99,10 @@ if '--load' in sys.argv:
         my_slice = int(sys.argv[1])
         max_slice = int(sys.argv[2])
         cfgs.external['wikidata']['loader'].load(my_slice, max_slice)
-    # if '--fast' in sys.argv:
-    #     my_slice = int(sys.argv[1])
-    #     max_slice = int(sys.argv[2])
-    #     cfgs.external['fast']['loader'].load(my_slice, max_slice)
+    if '--fast' in sys.argv:
+        my_slice = int(sys.argv[1])
+        max_slice = int(sys.argv[2])
+        cfgs.external['fast']['loader'].load(my_slice, max_slice)
 
 ### LOAD INDEXES
 if '--load-index' in sys.argv:

--- a/manage-data.py
+++ b/manage-data.py
@@ -99,10 +99,10 @@ if '--load' in sys.argv:
         my_slice = int(sys.argv[1])
         max_slice = int(sys.argv[2])
         cfgs.external['wikidata']['loader'].load(my_slice, max_slice)
-    if '--fast' in sys.argv:
-        my_slice = int(sys.argv[1])
-        max_slice = int(sys.argv[2])
-        cfgs.external['fast']['loader'].load(my_slice, max_slice)
+    # if '--fast' in sys.argv:
+    #     my_slice = int(sys.argv[1])
+    #     max_slice = int(sys.argv[2])
+    #     cfgs.external['fast']['loader'].load(my_slice, max_slice)
 
 ### LOAD INDEXES
 if '--load-index' in sys.argv:

--- a/manage-data.py
+++ b/manage-data.py
@@ -99,6 +99,10 @@ if '--load' in sys.argv:
         my_slice = int(sys.argv[1])
         max_slice = int(sys.argv[2])
         cfgs.external['wikidata']['loader'].load(my_slice, max_slice)
+    if '--fast' in sys.argv:
+        my_slice = int(sys.argv[1])
+        max_slice = int(sys.argv[2])
+        cfgs.external['fast']['loader'].load(my_slice, max_slice)
 
 ### LOAD INDEXES
 if '--load-index' in sys.argv:

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -54,3 +54,6 @@ class ViafLoader(Loader):
         fh.close()
         self.out_cache.commit()
 
+class FastLoader(ViafLoader):
+    pass
+

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -69,7 +69,6 @@ class FastLoader(ViafLoader):
         x = 0
         done_x = 0
 
-        #self.total = len(members)
 
         for f in members:
             if not f.endswith(".marcxml"):

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -60,7 +60,7 @@ class FastLoader(ViafLoader):
     def __init__(self, config):
         super().__init__(config)
 
-    def load(self, slicen=None, maxSlice=None):
+    def load(self):
 
         start = time.time()
         fh = zipfile.ZipFile(self.in_path)

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -75,24 +75,25 @@ class FastLoader(ViafLoader):
             if not f.endswith(".marcxml"):
                 pass
             facet = fh.open(f)
-            #ident = f
-
+            
             l = facet.read()
             try:
                 facet.close()
             except:
                 pass
 
-            records = etree.fromstring(l).xpath('//mx:record')
+            ns = {'mx': 'http://www.loc.gov/MARC21/slim'}
+            records = etree.fromstring(l).xpath('//mx:record', namespaces=ns)
             for record in records:
                 record_str = etree.tostring(record).decode('utf-8')
-                print(record_str)
-                break
+                identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=ns)
+                if controlfield:
+                    ident = controlfield[0].text
 
             x += 1
             done_x += 1
-            new = {"xml": xml}
-            self.out_cache[what] = new
+            new = {"xml": record_str}
+            self.out_cache[ident] = new
 
             if not done_x % 10000:
                 t = time.time() - start

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -75,7 +75,7 @@ class FastLoader(ViafLoader):
             if not f.endswith(".marcxml"):
                 pass
             facet = fh.open(f)
-            
+
             l = facet.read()
             try:
                 facet.close()
@@ -83,16 +83,19 @@ class FastLoader(ViafLoader):
                 pass
 
             ns = {'mx': 'http://www.loc.gov/MARC21/slim'}
-            records = etree.fromstring(l).xpath('//mx:record', namespaces=ns)
+            tree = etree.fromstring(l)
+            records = tree.xpath('//mx:record', namespaces=ns)
             for record in records:
-                record_str = etree.tostring(record).decode('utf-8')
                 identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=ns)
                 if controlfield:
                     ident = controlfield[0].text
+                    ident = ident.split("fst")[-1]
+                    if ident.startswith("0"):
+                        ident = ident[1:]
 
             x += 1
             done_x += 1
-            new = {"xml": record_str}
+            new = {"xml": record}
             self.out_cache[ident] = new
 
             if not done_x % 10000:

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -76,23 +76,21 @@ class FastLoader(ViafLoader):
                 pass
             facet = fh.open(f)
 
-            l = facet.read()
+            tree = etree.parse(facet)
             try:
                 facet.close()
             except:
                 pass
-            tree = etree.parse(l)
-            root = tree.getroot()
-            nss = root.nsmap            
 
+            nss = {'mx': 'http://www.loc.gov/MARC21/slim'} 
             records = tree.xpath('//mx:record', namespaces=nss)
             for record in records:
                 identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=nss)
-                if controlfield:
-                    ident = controlfield[0].text
+                if identfield:
+                    ident = identfield[0].text
                     ident = ident.split("fst")[-1]
                     if ident.startswith("0"):
-                        ident = ident[1:]
+                        ident = ident.lstrip('0')
 
             x += 1
             done_x += 1

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -91,17 +91,17 @@ class FastLoader(ViafLoader):
                     if ident.startswith("0"):
                         ident = ident.lstrip('0')
 
-            x += 1
-            done_x += 1
-            new = {"xml": record}
-            self.out_cache[ident] = new
+        #     x += 1
+        #     done_x += 1
+        #     new = {"xml": record}
+        #     self.out_cache[ident] = new
 
-            if not done_x % 10000:
-                t = time.time() - start
-                xps = x/t
-                ttls = self.total / xps
-                print(f"{x} in {t} = {xps}/s --> {ttls} total ({ttls/3600} hrs)")
-        fh.close()
-        self.out_cache.commit()
+        #     if not done_x % 10000:
+        #         t = time.time() - start
+        #         xps = x/t
+        #         ttls = self.total / xps
+        #         print(f"{x} in {t} = {xps}/s --> {ttls} total ({ttls/3600} hrs)")
+        # fh.close()
+        # self.out_cache.commit()
 
 

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -56,27 +56,30 @@ class ViafLoader(Loader):
         self.out_cache.commit()
 
 class FastLoader(ViafLoader):
-    
+
     def __init__(self, config):
         super().__init__(config)
 
     def load(self, slicen=None, maxSlice=None):
 
+        start = time.time()
         fh = zipfile.ZipFile(self.in_path)
+        members = fh.namelist()
 
-        xstart = time.time()
         x = 0
         done_x = 0
-        l = 1
 
-        start = time.time()
-        while l:
-            l = fh.readline()
-            if not l:
-                break
-            if maxSlice is not None and x % maxSlice - slicen != 0:
-                x+= 1
-                continue
+        self.total = len(members)
+
+        for ti in members:
+            facet = fh.open(ti)
+            ident = ti
+
+            l = bio.read()
+            try:
+                bio.close()
+            except:
+                pass
 
             l = l.decode('utf-8')
             what, xml = l.split('\t')
@@ -92,4 +95,5 @@ class FastLoader(ViafLoader):
                 print(f"{x} in {t} = {xps}/s --> {ttls} total ({ttls/3600} hrs)")
         fh.close()
         self.out_cache.commit()
+
 

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -69,11 +69,13 @@ class FastLoader(ViafLoader):
         x = 0
         done_x = 0
 
-        self.total = len(members)
+        #self.total = len(members)
 
-        for ti in members:
-            facet = fh.open(ti)
-            ident = ti
+        for f in members:
+            if not f.endswith(".marcxml"):
+                pass
+            facet = fh.open(f)
+            #ident = f
 
             l = facet.read()
             try:
@@ -82,7 +84,13 @@ class FastLoader(ViafLoader):
                 pass
 
             l = l.decode('utf-8')
-            what, xml = l.split('\t')
+            records = l.split("</mx:record>")
+            for i, record in enumerate(records):
+                if '<mx:record' in record:
+                    record = record.split("<mx:record")[1]
+                    print(record)
+                    break
+
             x += 1
             done_x += 1
             new = {"xml": xml}

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -81,12 +81,13 @@ class FastLoader(ViafLoader):
                 facet.close()
             except:
                 pass
+            tree = etree.parse(l)
+            root = tree.getroot()
+            nss = root.nsmap            
 
-            ns = {'mx': 'http://www.loc.gov/MARC21/slim'}
-            tree = etree.fromstring(l)
-            records = tree.xpath('//mx:record', namespaces=ns)
+            records = tree.xpath('//mx:record', namespaces=nss)
             for record in records:
-                identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=ns)
+                identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=nss)
                 if controlfield:
                     ident = controlfield[0].text
                     ident = ident.split("fst")[-1]

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -91,17 +91,17 @@ class FastLoader(ViafLoader):
                     if ident.startswith("0"):
                         ident = ident.lstrip('0')
 
-        #     x += 1
-        #     done_x += 1
-        #     new = {"xml": record}
-        #     self.out_cache[ident] = new
+            x += 1
+            done_x += 1
+            new = {"xml": record}
+            self.out_cache[ident] = new
 
-        #     if not done_x % 10000:
-        #         t = time.time() - start
-        #         xps = x/t
-        #         ttls = self.total / xps
-        #         print(f"{x} in {t} = {xps}/s --> {ttls} total ({ttls/3600} hrs)")
-        # fh.close()
-        # self.out_cache.commit()
+            if not done_x % 10000:
+                t = time.time() - start
+                xps = x/t
+                ttls = self.total / xps
+                print(f"{x} in {t} = {xps}/s --> {ttls} total ({ttls/3600} hrs)")
+        fh.close()
+        self.out_cache.commit()
 
 

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -85,11 +85,12 @@ class FastLoader(ViafLoader):
 
             l = l.decode('utf-8')
             records = l.split("</mx:record>")
-            for i, record in enumerate(records):
-                if '<mx:record' in record:
-                    record = record.split("<mx:record")[1]
-                    print(record)
-                    break
+            print(records)
+            # for i, record in enumerate(records):
+            #     if '<mx:record' in record:
+            #         record = record.split("<mx:record")[1]
+            #         print(record)
+            #         break
 
             x += 1
             done_x += 1

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -83,14 +83,11 @@ class FastLoader(ViafLoader):
             except:
                 pass
 
-            l = l.decode('utf-8')
-            records = l.split("</mx:record>")
-            print(records)
-            # for i, record in enumerate(records):
-            #     if '<mx:record' in record:
-            #         record = record.split("<mx:record")[1]
-            #         print(record)
-            #         break
+            records = etree.fromstring(l).xpath('//mx:record')
+            for record in records:
+                record_str = etree.tostring(record).decode('utf-8')
+                print(record_str)
+                break
 
             x += 1
             done_x += 1

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -75,9 +75,9 @@ class FastLoader(ViafLoader):
             facet = fh.open(ti)
             ident = ti
 
-            l = bio.read()
+            l = facet.read()
             try:
-                bio.close()
+                facet.close()
             except:
                 pass
 

--- a/pipeline/sources/authorities/oclc/loader.py
+++ b/pipeline/sources/authorities/oclc/loader.py
@@ -84,7 +84,11 @@ class FastLoader(ViafLoader):
             nss = {'mx': 'http://www.loc.gov/MARC21/slim'} 
             records = tree.xpath('//mx:record', namespaces=nss)
             for record in records:
-                identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=nss)
+                try:
+                    identfield = record.xpath('//mx:controlfield[@tag="001"]', namespaces=nss)
+                except:
+                    #no id??
+                    continue
                 if identfield:
                     ident = identfield[0].text
                     ident = ident.split("fst")[-1]


### PR DESCRIPTION
loader and manage-data updated to call from command line.
I think this works--there's like 56K record in FAST datacache already from previous loading or fetching--I didn't want to clear it without checking with you first but my next step would be to fully load from the zip file, then I can work through the mapper.

my config:
```
{
	"name": "fast",
	"type": "external",
	"namespace": "https://id.worldcat.org/fast/",
	"matches": ["id.worldcat.org/fast/"],
	"fetch": "https://id.worldcat.org/fast/{identifier}.rdf.xml",
        "wikidata_property": ["P2163"],
        "merge_order": 75,
	"totalRecords":1800000,
    
	"fetcherClass": "sources.authorities.oclc.fetcher.ViafFetcher",
	"mapperClass": "sources.authorities.oclc.mapper.ViafMapper",
	"loaderClass": "sources.authorities.oclc.loader.FastLoader",

    "inverseEquivDbPath": "",        
	"reconcileDumpPath": "",
    "dumpFilePath": "fast/FASTAll.marcxml.zip"

}
```