### PR TITLE
remove test for inception

### DIFF
--- a/pipeline/sources/general/wikidata/mapper.py
+++ b/pipeline/sources/general/wikidata/mapper.py
@@ -160,7 +160,7 @@ class WdMapper(Mapper, WdConfigManager):
             typ = opts[0][0]
             return class_dist[typ]
         else:
-            return None
+            return class_dist['type']
 
 
     def process_only_label(self, data, top):

--- a/pipeline/sources/general/wikidata/mapper.py
+++ b/pipeline/sources/general/wikidata/mapper.py
@@ -158,8 +158,6 @@ class WdMapper(Mapper, WdConfigManager):
         if opts:
             opts.sort(key=lambda x: x[1], reverse=True)
             typ = opts[0][0]
-            if "P571" in data and typ == "place" and len(opts) > 1:
-                typ = opts[1][0]
             return class_dist[typ]
         else:
             return None


### PR DESCRIPTION
I think we should remove this test.
The logic isn't right and we're creating duplicate records in different Classes for no reason.

All kinds of Places can have inceptions--countries, institutions (as Places), etc.
My code picked up ~500k times we divert the Class to something else, and in spotchecking, none were better choices.


export is here:
[data_changes.csv](https://github.com/user-attachments/files/15974051/data_changes.csv)
