### PR TITLE
Change table existence test to query PG metadata to avoid lockups

### DIFF
--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -93,7 +93,7 @@ class PooledCache(object):
             print(" ... execute select 1")
             cursor.execute(qry, (self.name,))
             res = cursor.fetchone()
-            print(" ... returned")
+            print(f" ... returned: {res}")
             if res is None:
                 # No such table, build it.
                 print(f"Making cache table {self.name}")

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -26,8 +26,9 @@ class PoolManager(object):
         self.pool = None
 
     def make_pool(self, name, host=None, port=None, user=None, password=None, dbname=None):   
-        print(" PG making connection")
+        print(" pool requested")
         if self.conn is None:
+            print("  ... making new connection")
             if host:
                 # TCP/IP
                 self.conn = psycopg2.connect(host=host, port=port, user=user, password=password, dbname=dbname)
@@ -37,7 +38,8 @@ class PoolManager(object):
                 self.conn = psycopg2.connect(user=user, dbname=dbname)
                 self.iterating_conn = psycopg2.connect(user=user, dbname=dbname)
             self.pool = name
-        print(" ... made")
+            print(" ... made")
+        print(" pool returned")
 
     def get_conn(self, name, itr=False):
         print("  pool was asked for conn")
@@ -71,7 +73,6 @@ class PooledCache(object):
         self.iterating_conn = None
 
         print(f"INIT: {self.name}")
-        print("  about to make pool")
         if config['host']:
             # TCP/IP
             pname = f"{config['host']}:{config['port']}/{config['dbname']}"

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -70,7 +70,8 @@ class PooledCache(object):
         self.conn = None
         self.iterating_conn = None
 
-        print(" cache in init about to make pool")
+        print("INIT: {self.name}")
+        print("  about to make pool")
         if config['host']:
             # TCP/IP
             pname = f"{config['host']}:{config['port']}/{config['dbname']}"
@@ -84,7 +85,7 @@ class PooledCache(object):
             poolman.make_pool(pname, user=self.config['user'], dbname=self.config['dbname'])
 
 
-        print(" cache in init about to test exists")
+        print("  about to test exists")
         # Test that our table exists
         qry = f'SELECT 1 FROM {self.name} LIMIT 1'
         with self._cursor(internal=False) as cursor:    
@@ -95,6 +96,8 @@ class PooledCache(object):
                 print(f"Making cache table {self.name}")
                 self.conn.rollback()
                 self._make_table()
+        print("  tested")
+
 
     def shutdown(self):
         # Close our connections
@@ -117,7 +120,7 @@ class PooledCache(object):
         else:
             conn = self.conn
 
-        print ("about to issue query")
+        print(" about to make cursor")
 
         if internal:
             # ensure uniqueness across multiple instances of the code
@@ -130,6 +133,7 @@ class PooledCache(object):
             # Need this for creating the tables/indexes
             cursor = conn.cursor(cursor_factory=RealDictCursor)
 
+        print(" Made cursor") 
         return cursor
 
     # --- pgcache ---

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -26,6 +26,7 @@ class PoolManager(object):
         self.pool = None
 
     def make_pool(self, name, host=None, port=None, user=None, password=None, dbname=None):   
+        print(" PG making connection")
         if self.conn is None:
             if host:
                 # TCP/IP
@@ -36,8 +37,10 @@ class PoolManager(object):
                 self.conn = psycopg2.connect(user=user, dbname=dbname)
                 self.iterating_conn = psycopg2.connect(user=user, dbname=dbname)
             self.pool = name
+        print(" ... made")
 
     def get_conn(self, name, itr=False):
+        print("asked for conn")
         if itr == False:
             return self.conn
         else:
@@ -66,6 +69,8 @@ class PooledCache(object):
         self.name = config['name'] + '_' + config['tabletype']
         self.conn = None
         self.iterating_conn = None
+
+        print(" cache in init about to make pool")
         if config['host']:
             # TCP/IP
             pname = f"{config['host']}:{config['port']}/{config['dbname']}"
@@ -78,6 +83,8 @@ class PooledCache(object):
             self.pool_name = pname
             poolman.make_pool(pname, user=self.config['user'], dbname=self.config['dbname'])
 
+
+        print(" cache in init about to test exists")
         # Test that our table exists
         qry = f'SELECT 1 FROM {self.name} LIMIT 1'
         with self._cursor(internal=False) as cursor:    
@@ -109,6 +116,8 @@ class PooledCache(object):
             conn = self.iterating_conn
         else:
             conn = self.conn
+
+        print ("about to issue query")
 
         if internal:
             # ensure uniqueness across multiple instances of the code

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -40,7 +40,7 @@ class PoolManager(object):
         print(" ... made")
 
     def get_conn(self, name, itr=False):
-        print("asked for conn")
+        print("  pool was asked for conn")
         if itr == False:
             return self.conn
         else:
@@ -70,7 +70,7 @@ class PooledCache(object):
         self.conn = None
         self.iterating_conn = None
 
-        print("INIT: {self.name}")
+        print(f"INIT: {self.name}")
         print("  about to make pool")
         if config['host']:
             # TCP/IP

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -90,7 +90,9 @@ class PooledCache(object):
         qry = f'SELECT 1 FROM {self.name} LIMIT 1'
         with self._cursor(internal=False) as cursor:    
             try:
+                print(" ... execute select 1")
                 cursor.execute(qry)
+                print(" ... returned")
             except psycopg2.errors.UndefinedTable:
                 # No such table, build it.
                 print(f"Making cache table {self.name}")

--- a/pipeline/storage/cache/postgres.py
+++ b/pipeline/storage/cache/postgres.py
@@ -88,13 +88,13 @@ class PooledCache(object):
 
         print("  about to test exists")
         # Test that our table exists
-        qry = f'SELECT 1 FROM {self.name} LIMIT 1'
+        qry = 'SELECT 1 FROM pg_tables WHERE tablename = %s'
         with self._cursor(internal=False) as cursor:    
-            try:
-                print(" ... execute select 1")
-                cursor.execute(qry)
-                print(" ... returned")
-            except psycopg2.errors.UndefinedTable:
+            print(" ... execute select 1")
+            cursor.execute(qry, (self.name,))
+            res = cursor.fetchone()
+            print(" ... returned")
+            if res is None:
                 # No such table, build it.
                 print(f"Making cache table {self.name}")
                 self.conn.rollback()


### PR DESCRIPTION
A better test that doesn't involve rollbacks and exception handling.