### PR TITLE
Rewrite debug-reconcile to use reconciler code

### DIFF
--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -165,7 +165,7 @@ node_labels = {node: node for node in G.nodes()}
 edge_color_values = ['black' for _ in G.edges()] 
 
 pos = nx.spring_layout(G, k=1)
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+nodes = nx.draw_networkx_nodes(G, pos, labels=idents, node_color=node_color_values, node_size=150)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -98,7 +98,7 @@ inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
 while inputs:
     inp = inputs.pop(0)
     reconciler.reconcile(inp[3])
-    eqs = inp['data'].get('equivalent', [])
+    eqs = inp[3]['data'].get('equivalent', [])
     for e in eqs:
         for i in inputs[:]:
             if e == i[2]:

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -87,7 +87,7 @@ for u in uris:
         continue
     (base, qua) = cfgs.split_qua(u)
     (src, ident) = cfgs.split_uri(base)
-    inputs.append((src, ident, src['acquirer'].acquire(ident)))
+    inputs.append((src, ident, u, src['acquirer'].acquire(ident)))
 
 inputs.sort(key=lambda x: x[0]['datacache'].len_estimate())
 inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
@@ -95,7 +95,16 @@ inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
 # start with inputs[0] and reconcile
 # then filter out any in the new equivalents, and iterate until we find them all
 
-reconciler.reconcile(inputs[0][2])
+while inputs:
+    inp = inputs.pop(0)
+    reconciler.reconcile(inp[3])
+    eqs = inp['data'].get('equivalent', [])
+    for e in eqs:
+        for i in inputs[:]:
+            if e == i[2]:
+                inputs.remove(i) 
+                break
+
 
 raise ValueError()
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -96,10 +96,12 @@ while inputs:
     inp = inputs.pop(0)
     reconciler.reconcile(inp[3])
     eqs = inp[3]['data'].get('equivalent', [])
+    print(eqs)
+    print([x[2] for x in inputs])
     for e in eqs:
         for i in inputs[:]:
             if e == i[2]:
-                print(f"removing {e}")
+                print(f"*** Removing {e}")
                 inputs.remove(i) 
                 break
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -102,6 +102,7 @@ while inputs:
     for e in eqs:
         for i in inputs[:]:
             if e == i[2]:
+                print(f"removing {e}")
                 inputs.remove(i) 
                 break
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -165,7 +165,8 @@ node_labels = {node: node for node in G.nodes()}
 edge_color_values = ['black' for _ in G.edges()] 
 
 pos = nx.spring_layout(G, k=1)
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150, label="nodes?")
+for n, lbl in idents.items():
+    nx.draw_networkx_nodes(G, pos, nodelist=[n], node_color=node_color_values, node_size=150, label=lbl)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -165,8 +165,8 @@ node_labels = {node: node for node in G.nodes()}
 edge_color_values = ['black' for _ in G.edges()] 
 
 pos = nx.spring_layout(G, k=1)
-for n, lbl in idents.items():
-    nx.draw_networkx_nodes(G, pos, nodelist=[n], node_color=node_color_values, node_size=150, label=lbl)
+for lbl, n in idents.items():
+    nx.draw_networkx_nodes(G, pos, nodelist=[n], node_color=node_color_values, node_size=150, label=f"{n}: {lbl}")
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -67,7 +67,7 @@ if yuid != yuid2:
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
 reconciler.debug = True
-config['all_configs'].debug_reconciliation = True
+cfgs.debug_reconciliation = True
 
 
 curr = "0"

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -92,6 +92,8 @@ inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
 # start with inputs[0] and reconcile
 # then filter out any in the new equivalents, and iterate until we find them all
 
+processed = []
+
 while inputs:
     inp = inputs.pop(0)
     reconciler.reconcile(inp[3])
@@ -105,7 +107,7 @@ while inputs:
                 print(f"*** Removing {e}")
                 inputs.remove(i) 
                 break
-
+    processed.append(inp)
 
 raise ValueError()
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -166,7 +166,7 @@ edge_color_values = ['black' for _ in G.edges()]
 
 pos = nx.spring_layout(G, k=1)
 for lbl, n in idents.items():
-    nx.draw_networkx_nodes(G, pos, nodelist=[n], node_color=node_color_values, node_size=150, label=f"{n}: {lbl}")
+    nx.draw_networkx_nodes(G, pos, nodelist=[n], node_color=['skyblue'], node_size=150, label=f"{n}: {lbl}")
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -116,7 +116,7 @@ while inputs:
 curr_id = "0"
 idents = {}
 edge_labels = {}
-extra_nss = {'http://id.worldcat.org/fast/':'fast'}
+extra_nss = {'http://id.worldcat.org/fast':'fast'}
 G = nx.Graph()
 
 for (k,v) in reconciler.debug_graph.items():
@@ -182,9 +182,10 @@ node_labels = {node: node for node in G.nodes()}
 edge_color_values = ['black' for _ in G.edges()] 
 pos = nx.spring_layout(G, k=1)
 
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=50)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
+nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')
 
 #plt.legend([nodes, edges], ['Nodes', 'Edges'])
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -116,7 +116,7 @@ while inputs:
 curr_id = "0"
 idents = {}
 edge_labels = {}
-
+extra_nss = {'http://id.worldcat.org/fast/':'fast'}
 G = nx.Graph()
 
 for (k,v) in reconciler.debug_graph.items():
@@ -131,8 +131,16 @@ for (k,v) in reconciler.debug_graph.items():
         try:
             vil = idents[vi[0]]
         except:
-            (src,ident) = cfgs.split_uri(vi[0])
-            vil = f"{src['name']}:{curr_id}"
+            try:
+                (src,ident) = cfgs.split_uri(vi[0])
+                vil = f"{src['name']}:{curr_id}"
+            except:
+                # Could be fast or could be junk
+                (ns,idt) = vi[0].rsplit('/', 1)
+                if ns in extra_nss:
+                    vil = f"{extra_nss[ns]}:{curr_id}"
+                else:
+                    vil =f"???:{curr_id}"
             idents[vi[0]] = vil
             curr_id = chr(ord(curr_id)+1)        
         G.add_edge(kl, vil)

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -66,13 +66,7 @@ if yuid != yuid2:
 
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
-cfgs.external['gbif']['fetcher'].enabled = True
-
-curr = "0"
 uris = idmap[yuid]
-idents = {}
-graph = {}
-names = {}
 
 ### Idea: We know the final result, try to reconstruct it by following what the reconciler
 # does, but tracking which URIs prompted the inclusion of which others
@@ -109,32 +103,40 @@ while inputs:
                 break
     processed.append(inp)
 
-raise ValueError()
+
+# We've now built reconciler.debug_graph
+# turn it into a networkx graph with shorter node ids
 
 
 
 
+# curr = chr(ord(curr)+1)
 
 
+curr_id = "0"
+idents = {}
+edge_labels = {}
 
-curr = chr(ord(curr)+1)
 G = nx.Graph()
-G.add_nodes_from(list(idents.values()))
 
-new_graph = {}
-for (k,v) in graph.items():
-    subj = idents[k]
-    l = []
-    for u in v:
-        if u in idents:
-            obj = idents[u]
-            l.append(obj)
-            G.add_edge(subj, obj)
-        else:
-            pass
-    l.sort()
-    new_graph[subj] = l
-
+for (k,v) in reconciler.debug_graph.items():
+    try:
+        kl = idents[k]
+    except:
+        (src,ident) = cfgs.split_uri(k)
+        kl = f"{src['name']}:{curr_id}"
+        idents[k] = kl
+        curr_id = chr(ord(curr_id)+1)
+    for vi in v:
+        try:
+            vil = idents[vi[0]]
+        except:
+            (src,ident) = cfgs.split_uri(vi[0])
+            vil = f"{src['name']}:{curr_id}"
+            idents[vi[0]] = vil
+            curr_id = chr(ord(curr_id)+1)        
+        G.add_edge(kl, vil)
+        edge_labels[(kl, vil)] = vi[1]
 
 key = []
 inv_ident = {}

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -14,6 +14,7 @@ import networkx as nx
 load_dotenv()
 basepath = os.getenv('LUX_BASEPATH', "")
 cfgs = Config(basepath=basepath)
+cfgs.debug_reconciliation = True # Ensure debug is on
 idmap = cfgs.instantiate_map('idmap')['store']
 networkmap = cfgs.instantiate_map('networkmap')['store']
 cfgs.cache_globals()
@@ -66,13 +67,9 @@ if yuid != yuid2:
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
-reconciler.debug = True
-cfgs.debug_reconciliation = True
-
 
 curr = "0"
 uris = idmap[yuid]
-
 idents = {}
 graph = {}
 names = {}

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -107,12 +107,6 @@ while inputs:
 # We've now built reconciler.debug_graph
 # turn it into a networkx graph with shorter node ids
 
-
-
-
-# curr = chr(ord(curr)+1)
-
-
 curr_id = "0"
 idents = {}
 edge_labels = {}
@@ -165,29 +159,18 @@ print(f"\nShortest path from {from_p} to {to_p}")
 print(" --> ".join([inv_ident[x] for x in nx.shortest_path(G, idents[from_p], idents[to_p])]))
 
 
-#this code worked until I introduced reconcile, now it takes WAY too long to compile. 
-#we can't use the DAG function because we have cycles in our graph
-# print("\nLongest Path:")
-# longest_path = []
-# for node in G.nodes:
-#     for path in nx.all_simple_paths(G, source=node, target=idents[to_p]):
-#         if len(path) > len(longest_path):
-#             longest_path = path
-# print(" --> ".join([inv_ident[x] for x in longest_path]))
-
-
 plt.figure(figsize=(12, 12))
 node_color_values = ['skyblue' for _ in G.nodes()]  
 node_labels = {node: node for node in G.nodes()} 
 edge_color_values = ['black' for _ in G.edges()] 
-pos = nx.spring_layout(G, k=1)
 
-nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=50)
+pos = nx.spring_layout(G, k=1)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150)
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')
 
-#plt.legend([nodes, edges], ['Nodes', 'Edges'])
+plt.legend()
 
 plt.savefig("graph.png")
 plt.show(block=True) 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -155,7 +155,7 @@ for (k,v) in idents.items():
 key.sort()
 print("  -- Key --")
 for k in key:
-   print(f"  {k[0]:<16}{k[1]} ({names.get(k[1], '?')})")
+   print(f"  {k[0]:<16}{k[1]}")
 
 print("\nConnected Nodes:")
 for sets in list(nx.connected_components(G)):

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -66,12 +66,15 @@ if yuid != yuid2:
 # --- set up environment ---
 reconciler = Reconciler(cfgs, idmap, networkmap)
 cfgs.external['gbif']['fetcher'].enabled = True
+reconciler.debug = True
+config['all_configs'].debug_reconciliation = True
+
 
 curr = "0"
-idents = {}
-# uri: [uris,that,are,connected]
-graph = {}
 uris = idmap[yuid]
+
+idents = {}
+graph = {}
 names = {}
 
 ### Idea: We know the final result, try to reconstruct it by following what the reconciler
@@ -89,7 +92,12 @@ for u in uris:
 inputs.sort(key=lambda x: x[0]['datacache'].len_estimate())
 inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
 
+# start with inputs[0] and reconcile
+# then filter out any in the new equivalents, and iterate until we find them all
 
+reconciler.reconcile(inputs[0][2])
+
+raise ValueError()
 
 
 
@@ -98,8 +106,6 @@ inputs.sort(key=lambda x: 1 if x[0]['type'] == 'internal' else 2)
 
 
 curr = chr(ord(curr)+1)
-
-
 G = nx.Graph()
 G.add_nodes_from(list(idents.values()))
 

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -96,11 +96,12 @@ while inputs:
     inp = inputs.pop(0)
     reconciler.reconcile(inp[3])
     eqs = inp[3]['data'].get('equivalent', [])
+    eqs = [x['id'] for x in eqs]
     print(eqs)
     print([x[2] for x in inputs])
     for e in eqs:
         for i in inputs[:]:
-            if e == i[2]:
+            if i[2].startswith(e):
                 print(f"*** Removing {e}")
                 inputs.remove(i) 
                 break

--- a/debug-reconcile.py
+++ b/debug-reconcile.py
@@ -165,7 +165,7 @@ node_labels = {node: node for node in G.nodes()}
 edge_color_values = ['black' for _ in G.edges()] 
 
 pos = nx.spring_layout(G, k=1)
-nodes = nx.draw_networkx_nodes(G, pos, labels=idents, node_color=node_color_values, node_size=150)
+nodes = nx.draw_networkx_nodes(G, pos, node_color=node_color_values, node_size=150, label="nodes?")
 edges = nx.draw_networkx_edges(G, pos, edge_color=edge_color_values)
 nx.draw_networkx_labels(G, pos, labels=node_labels, font_size=14)
 nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels,font_color='red')

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -162,16 +162,14 @@ class LmdbReconciler(Reconciler):
                     if typ is not None and my_type == typ:
                         if self.debug:
                             try:
-                                self.debug_graph[e].append((f"{self.namespace}{uri}", 'nm'))
+                                self.debug_graph[rec['id']].append((f"{self.namespace}{k}", 'nm'))
                             except:
-                                self.debug_graph[e] = [(f"{self.namespace}{uri}", 'nm')]
+                                self.debug_graph[rec['id']] = [(f"{self.namespace}{k}", 'nm')]
                         try:
                             matches[k].append(val)
                         except:
                             matches[k] = [val]
                         break
-
-
 
 
         if reconcileType in ['all', 'uri']:

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -160,11 +160,19 @@ class LmdbReconciler(Reconciler):
                         k = self.name_index[val]
                         typ = None
                     if typ is not None and my_type == typ:
+                        if self.debug:
+                            try:
+                                self.debug_graph[e].append((f"{self.namespace}{uri}", 'nm'))
+                            except:
+                                self.debug_graph[e] = [(f"{self.namespace}{uri}", 'nm')]
                         try:
                             matches[k].append(val)
                         except:
                             matches[k] = [val]
                         break
+
+
+
 
         if reconcileType in ['all', 'uri']:
             for e in self.extract_uris(rec):

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -13,6 +13,7 @@ class Reconciler(object):
         self.namespace = config['namespace']
         self.configs = config['all_configs']
         self.debug = config['all_configs'].debug_reconciliation
+        self.debug_graph = {}
 
     def should_reconcile(self, rec, reconcileType="all"):
         if 'data' in rec:
@@ -169,12 +170,18 @@ class LmdbReconciler(Reconciler):
             for e in self.extract_uris(rec):
                 if e in self.id_index:
                     (uri, typ) = self.id_index[e]
-                    if my_type != typ:
-                        if self.debug: print(f"cross-type match: record has {my_type} and external has {typ}")
+                    if my_type != typ and self.debug:
+                        print(f"cross-type match: record has {my_type} and external has {typ}")
                     try:
                         matches[uri].append(e)
                     except:
                         matches[uri] = [e]
+                    if self.debug:
+                        try:
+                            self.debug_graph[e].append((f"{self.namespace}{uri}", 'uri'))
+                        except:
+                            self.debug_graph[e] = [(f"{self.namespace}{uri}", 'uri')]
+
         if len(matches) == 1:
             return f"{self.namespace}{list(matches.keys())[0]}"
         elif matches:

--- a/pipeline/process/collector.py
+++ b/pipeline/process/collector.py
@@ -18,6 +18,7 @@ class Collector(object):
         self.networkmap = config.instantiate_map('networkmap')['store']        
         self.debug = config.debug_reconciliation
         self.global_reconciler = config.results['merged'].get('reconciler', None)
+        self.debug_graph
 
     def test_dates(self, botbr, botbx):
         if not botbr or not botbx:
@@ -181,7 +182,7 @@ class Collector(object):
                     xrlbl = xrec.get('_label', lbl)
                     rec['equivalent'].append({"id": xrid, "type": cls, "_label": xrlbl})
                     equiv_recs[xrec['id']] = xrec
-                    if self.debug: print(f"{xrid} / {xrlbl} into {rec['id']} tested okay")
+                    if self.debug: print(f"  {xrid} / {xrlbl} into {rec['id']} tested okay")
 
                 # 2. xrec is okay, so process *its* equivalents
                 if 'equivalent' in xrec:
@@ -248,6 +249,11 @@ class Collector(object):
                             if known or okay:
                                 equiv.append(eqid)
                                 if self.debug: print(f"       --> Adding {eqid} from {xrec['id']}")
+                                if self.debug:
+                                    try:
+                                        self.debug_graph[xrec['id']].append((eqid, 'eq'))
+                                    except:
+                                        self.debug_graph[xrec['id']] = [(eqid, 'eq')]
                             else:
                                 if self.debug: print(f"       --> NOT adding {eqid} from {xrec['id']}")
             done.append(uri)

--- a/pipeline/process/collector.py
+++ b/pipeline/process/collector.py
@@ -18,7 +18,7 @@ class Collector(object):
         self.networkmap = config.instantiate_map('networkmap')['store']        
         self.debug = config.debug_reconciliation
         self.global_reconciler = config.results['merged'].get('reconciler', None)
-        self.debug_graph
+        self.debug_graph = {}
 
     def test_dates(self, botbr, botbx):
         if not botbr or not botbx:

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -133,9 +133,12 @@ class Reconciler(object):
                     if self.debug and r.debug:
                         # fetch link-graph from reconciler
                         lg = r.debug_graph
+                        for (k,v) in lg.items():
+                            try:
+                                self.debug_graph[k].append(v)
+                            except:
+                                self.debug_graph[k] = [v]
                         r.debug_graph = {}
-                        print(r)
-                        print(lg)
                 except:
                     print(r)
                     raise

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -28,6 +28,9 @@ class Reconciler(object):
         except:
             self.filter_internal = False
 
+        self.debug_graph = {}
+
+
     def reconcile(self, record):
         if self.global_reconciler is None:
             self.global_reconciler = self.configs.results['merged']['reconciler']
@@ -43,6 +46,14 @@ class Reconciler(object):
             record['data']['equivalent'].append(me)
         else:
             record['data']['equivalent'] = [me]
+
+
+        if self.debug:
+            for eq in record['data']['equivalent']:
+                try:
+                    self.debug_graph[record['data']['id']].append(eq['id'])
+                except:
+                    self.debug_graph[record['data']['id']] = [eq['id']]
 
         if self.debug: print(f"\n--- {record['data']['id']} ---")
         leq = len(record['data'].get('equivalent', []))

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -144,9 +144,11 @@ class Reconciler(object):
                         # fetch link-graph from reconciler
                         lg = r.debug_graph
                         for (k,v) in lg.items():
-                            try:
-                                self.debug_graph[k].extend(v)
-                            except:
+                            if k in self.debug_graph:
+                                for vi in v:
+                                    if not vi in self.debug_graph[k]:
+                                        self.debug_graph[k].append(vi)
+                            else:
                                 self.debug_graph[k] = v
                         r.debug_graph = {}
                 except:

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -98,7 +98,16 @@ class Reconciler(object):
                     if self.debug: print("      (collecting)")
                     self.collector.collect(record)
                     cr_equivs = set([x['id'] for x in record['data'].get('equivalent', [])])
-                    if self.debug: print(f"cr_equivs: {cr_equivs}")                    
+                    if self.debug: print(f"cr_equivs: {cr_equivs}")
+                    if self.debug:
+                        lg = self.collector.debug_graph
+                        for (k,v) in lg.items():
+                            try:
+                                self.debug_graph[k].extend(v)
+                            except:
+                                self.debug_graph[k] = v
+                        self.collector.debug_graph = {}
+
         except Exception as e:
             print(f"\nERROR: Reconciling broke for {record['source']}/{record['identifier']}: {e}")
             raise

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -50,10 +50,11 @@ class Reconciler(object):
 
         if self.debug:
             for eq in record['data']['equivalent']:
-                try:
-                    self.debug_graph[record['data']['id']].append((eq['id'], 'eq'))
-                except:
-                    self.debug_graph[record['data']['id']] = [(eq['id'], 'eq')]
+                if eq['id'] != record['data']['id']:
+                    try:
+                        self.debug_graph[record['data']['id']].append((eq['id'], 'eq'))
+                    except:
+                        self.debug_graph[record['data']['id']] = [(eq['id'], 'eq')]
 
         if self.debug: print(f"\n--- {record['data']['id']} ---")
         leq = len(record['data'].get('equivalent', []))

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -135,9 +135,9 @@ class Reconciler(object):
                         lg = r.debug_graph
                         for (k,v) in lg.items():
                             try:
-                                self.debug_graph[k].append(v)
+                                self.debug_graph[k].extend(v)
                             except:
-                                self.debug_graph[k] = [v]
+                                self.debug_graph[k] = v
                         r.debug_graph = {}
                 except:
                     print(r)

--- a/pipeline/process/reconciler.py
+++ b/pipeline/process/reconciler.py
@@ -28,6 +28,7 @@ class Reconciler(object):
         except:
             self.filter_internal = False
 
+        # source-rec-uri: [(added-rec-uri, 'eq|uri|nm')]
         self.debug_graph = {}
 
 
@@ -47,13 +48,12 @@ class Reconciler(object):
         else:
             record['data']['equivalent'] = [me]
 
-
         if self.debug:
             for eq in record['data']['equivalent']:
                 try:
-                    self.debug_graph[record['data']['id']].append(eq['id'])
+                    self.debug_graph[record['data']['id']].append((eq['id'], 'eq'))
                 except:
-                    self.debug_graph[record['data']['id']] = [eq['id']]
+                    self.debug_graph[record['data']['id']] = [(eq['id'], 'eq')]
 
         if self.debug: print(f"\n--- {record['data']['id']} ---")
         leq = len(record['data'].get('equivalent', []))
@@ -130,6 +130,12 @@ class Reconciler(object):
                     # or a list (if the reconciler knows multiple sources,
                     #   or if there's more than one actual match to add from a single source)
                     newids = r.reconcile(record, reconcileType=reconcileType)
+                    if self.debug and r.debug:
+                        # fetch link-graph from reconciler
+                        lg = r.debug_graph
+                        r.debug_graph = {}
+                        print(r)
+                        print(lg)
                 except:
                     print(r)
                     raise

--- a/pipeline/sources/authorities/oclc/reconciler.py
+++ b/pipeline/sources/authorities/oclc/reconciler.py
@@ -58,7 +58,7 @@ class ViafReconciler(LmdbReconciler):
                             found = self.id_index[key]
                             ids[key] = found
                             if self.debug:
-                                print(f" VIAF Found: {eq} --> {found}")
+                                print(f" VIAF Found: {eq} --> {found}")                                
                                 try:
                                     self.debug_graph[eq].append((f"{self.namespace}{found}", 'uri'))
                                 except:

--- a/pipeline/sources/authorities/oclc/reconciler.py
+++ b/pipeline/sources/authorities/oclc/reconciler.py
@@ -55,8 +55,14 @@ class ViafReconciler(LmdbReconciler):
                     if eq.startswith(ns):
                         key = eq.replace(ns, f"{prefix}:")
                         if key in self.id_index:
-                            ids[key] = self.id_index[key]
-                            # print(f"Found: {eq} --> {self.index[key]}")
+                            found = self.id_index[key]
+                            ids[key] = found
+                            if self.debug:
+                                print(f" VIAF Found: {eq} --> {found}")
+                                try:
+                                    self.debug_graph[eq].append((f"{self.namespace}{found}", 'uri'))
+                                except:
+                                    self.debug_graph[eq] = [(f"{self.namespace}{found}", 'uri')]
                         elif "/viaf/" in eq:
                             # record assigned one already
                             truth = eq.rsplit('/',1)[1]

--- a/pipeline/sources/general/wikidata/reconciler.py
+++ b/pipeline/sources/general/wikidata/reconciler.py
@@ -72,7 +72,7 @@ class WdReconciler(LmdbReconciler, WdConfigManager):
                         key = eq.replace(ns, f"{prefix}:")
                         if key in self.id_index:
                             ids[key] = self.id_index[key]
-                            # print(f"Found: {eq} --> {self.id_index[key]}")
+                            print(f"  ---- WD Found: {eq} --> {self.id_index[key]}")
                         elif "wikidata.org/" in eq:
                             # record assigned one already
                             truth = eq.rsplit('/',1)[1]

--- a/pipeline/sources/general/wikidata/reconciler.py
+++ b/pipeline/sources/general/wikidata/reconciler.py
@@ -71,8 +71,14 @@ class WdReconciler(LmdbReconciler, WdConfigManager):
                     if eq.startswith(ns):
                         key = eq.replace(ns, f"{prefix}:")
                         if key in self.id_index:
-                            ids[key] = self.id_index[key]
-                            print(f"  ---- WD Found: {eq} --> {self.id_index[key]}")
+                            found = self.id_index[key]
+                            ids[key] = found
+                            if self.debug:
+                                print(f"  ---- WD Found: {eq} --> {found}")
+                                try:
+                                    self.debug_graph[eq].append((f"{self.namespace}{found}", 'uri'))
+                                except:
+                                    self.debug_graph[eq] = [(f"{self.namespace}{found}", 'uri')]
                         elif "wikidata.org/" in eq:
                             # record assigned one already
                             truth = eq.rsplit('/',1)[1]


### PR DESCRIPTION
The reconcilers and collector now record which records caused the inclusion of which other records when in debug mode.

debug-reconcile then collates them for the given record(s) and spits out the graph.