### PR TITLE
Fix lc mappertypos

### DIFF
--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -687,6 +687,7 @@ class LcnafMapper(LcMapper):
                         if fid.startswith("_:"):
                             if al.startswith("("):
                                 al = re.sub(r'^\(.*?\)\s*', '', al)
+                                print(f"al is {al}")
                             fid = self.build_recs_and_reconcile(al, "concept")
                         if fid:
                             if "authorities/names" in fid:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -586,6 +586,8 @@ class LcnafMapper(LcMapper):
                         lbl = lbl.get("@value", "")
 
                     txt = lbl.strip()
+                    if txt and "(" in txt:
+                        txt = re.sub(r'^\(.*?\)\s*', '', txt)
                     if txt:
                         if not bpid or bpid.startswith("_:"):
                             bpid = self.build_recs_and_reconcile(txt, "place")
@@ -648,6 +650,8 @@ class LcnafMapper(LcMapper):
                     if type(lbl) == dict:
                         lbl = lbl.get("@value", "")
                     txt = lbl.strip()
+                    if txt and "(" in txt:
+                        txt = re.sub(r'^\(.*?\)\s*', '', txt)
                     if txt:
                         if not dpid or dpid.startswith("_:"):
                             dpid = self.build_recs_and_reconcile(txt, "place")
@@ -682,7 +686,7 @@ class LcnafMapper(LcMapper):
                             al = al.get("@value", "")
                         if fid.startswith("_:"):
                             if al.startswith("("):
-                                al = al.split(" ")[-1]
+                                al = re.sub(r'^\(.*?\)\s*', '', al)
                             fid = self.build_recs_and_reconcile(al, "concept")
                         if fid:
                             if "authorities/names" in fid:
@@ -717,7 +721,7 @@ class LcnafMapper(LcMapper):
                             al = al.get("@value", "")
                         if oid.startswith("_:"):
                             if al.startswith("("):
-                                al = al.split(" ")[-1]
+                                al = re.sub(r'^\(.*?\)\s*', '', al)
                             oid = self.build_recs_and_reconcile(al, "concept")
                         if oid and "names" in oid:
                             # actually member_of
@@ -777,7 +781,7 @@ class LcnafMapper(LcMapper):
                         if type(lbl) == dict:
                             lbl = lbl["@value"]
                         if lbl.startswith("("):
-                            lbl = lbl.split(" ")[-1]
+                            lbl = re.sub(r'^\(.*?\)\s*', '', lbl)
                         gid = o.get("@id", "")
 
                         if (gid == "" or gid.startswith("_")) and lbl:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -687,7 +687,6 @@ class LcnafMapper(LcMapper):
                         if fid.startswith("_:"):
                             if al.startswith("("):
                                 al = re.sub(r'^\(.*?\)\s*', '', al)
-                                print(f"al is {al}")
                             fid = self.build_recs_and_reconcile(al, "concept")
                         if fid:
                             if "authorities/names" in fid:


### PR DESCRIPTION
noticed this was getting the bizarre Prof Activity of "States"--
https://lux-front-sbx.collections.yale.edu/view/group/2e68492c-ef49-46ac-ad1a-4960ff46986d

and realized the labels going to `build_recs_and_reconcile` in the LC Mapper weren't being formatted properly. 

Went through the mapper and added regex to remove the parens if exist.

note that for this example, it now just drops "Analgesics industry--United States" because that heading doesn't exist in our cache (nor on id.loc.gov)