### PR TITLE
bug in LCNAF mapper

### DIFF
--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -161,10 +161,11 @@ class LmdbReconciler(Reconciler):
                         typ = None
                     if typ is not None and my_type == typ:
                         if self.debug:
-                            try:
-                                self.debug_graph[rec['id']].append((f"{self.namespace}{k}", 'nm'))
-                            except:
-                                self.debug_graph[rec['id']] = [(f"{self.namespace}{k}", 'nm')]
+                            if rec['id']:
+                                try:
+                                    self.debug_graph[rec['id']].append((f"{self.namespace}{k}", 'nm'))
+                                except:
+                                    self.debug_graph[rec['id']] = [(f"{self.namespace}{k}", 'nm')]
                         try:
                             matches[k].append(val)
                         except:

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -161,7 +161,8 @@ class LmdbReconciler(Reconciler):
                         typ = None
                     if typ is not None and my_type == typ:
                         if self.debug:
-                            if rec['id']:
+                            recid = rec.get("id","")
+                            if recid:
                                 try:
                                     self.debug_graph[rec['id']].append((f"{self.namespace}{k}", 'nm'))
                                 except:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -454,19 +454,14 @@ class LcnafMapper(LcMapper):
             if type(record) == list:
                 # BAD CALLER!
                 rec = record
-        if rec:
-            print("got rec at line 451")
         if not rec["@graph"] or rec["@graph"] == {}:
-            print("returning none at line 457")
             return None
 
         new = LcMapper.transform(self, record, rectype, reference)
 
         if new and not rectype:
             rectype = self.guess_type(new)
-            print("got rectype at line 467")
         if not new or not rectype:
-            print("returning none at line 468")
             return None
 
 
@@ -494,6 +489,7 @@ class LcnafMapper(LcMapper):
             # if we have one
 
             if "madsrdf:identifiesRWO" in new:
+                print("got rwo at line 491")
                 rwo = new["madsrdf:identifiesRWO"]
                 if type(rwo) == list:
                     rwo = rwo[0]
@@ -541,6 +537,7 @@ class LcnafMapper(LcMapper):
                         top.classified_as = gender
 
                 if "madsrdf:birthDate" in rwo:
+                    print("got birthdate at line 539")
                     #'madsrdf:birthDate': {'@type': 'http://id.loc.gov/datatypes/edtf/EDTF', '@value': '1757-11-28'}
                     txt = ""
                     bd = rwo["madsrdf:birthDate"]

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -490,10 +490,9 @@ class LcnafMapper(LcMapper):
 
             if "madsrdf:identifiesRWO" in new:
                 rwo = new["madsrdf:identifiesRWO"]
-                print(f"got rwo {rwo}")
                 if type(rwo) == list:
                     rwo = rwo[0]
-                    print("rwo was a list")
+                    print(rwo)
 
                 # Name is rdfs:label, and copied from concept
                 if "madsrdf:gender" in rwo:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -418,11 +418,10 @@ class LcnafMapper(LcMapper):
         else:
             self.parenthetical_places = {}
 
-    def build_recs_and_reconcile(self, txt, ident, rectype=""):
+    def build_recs_and_reconcile(self, txt, rectype=""):
         # reconrec returns URI
 
         rec = {
-            "id" : ident
             "type": "",
             "identified_by": [
                 {
@@ -609,7 +608,7 @@ class LcnafMapper(LcMapper):
                 txt = re.sub(r'^\(.*?\)\s*', '', txt)
             if txt:
                 if not bpid or bpid.startswith("_:"):
-                    bpid = self.build_recs_and_reconcile(txt, top['id'], "place")
+                    bpid = self.build_recs_and_reconcile(txt, "place")
             if bpid:
                 # bpid is full uri
                 src, ident = self.config["all_configs"].split_uri(bpid)
@@ -673,7 +672,7 @@ class LcnafMapper(LcMapper):
                 txt = re.sub(r'^\(.*?\)\s*', '', txt)
             if txt:
                 if not dpid or dpid.startswith("_:"):
-                    dpid = self.build_recs_and_reconcile(txt, top['id'], "place")
+                    dpid = self.build_recs_and_reconcile(txt, "place")
             if dpid:
                 # dpid is full uri
                 src, ident = self.config["all_configs"].split_uri(dpid)
@@ -706,7 +705,7 @@ class LcnafMapper(LcMapper):
                 if fid.startswith("_:"):
                     if al.startswith("("):
                         al = re.sub(r'^\(.*?\)\s*', '', al)
-                    fid1 = self.build_recs_and_reconcile(al, top['id'], "concept")
+                    fid1 = self.build_recs_and_reconcile(al, "concept")
                 if fid1:
                     if "authorities/names" in fid1:
                         continue
@@ -737,7 +736,7 @@ class LcnafMapper(LcMapper):
                 if oid.startswith("_:"):
                     if al.startswith("("):
                         al = re.sub(r'^\(.*?\)\s*', '', al)
-                    oid = self.build_recs_and_reconcile(al, top['id'], "concept")
+                    oid = self.build_recs_and_reconcile(al, "concept")
                 if oid and "names" in oid:
                     # actually member_of
                     top.member_of = model.Group(ident=oid, label=al)
@@ -800,7 +799,7 @@ class LcnafMapper(LcMapper):
                 gid = o.get("@id", "")
 
                 if (gid == "" or gid.startswith("_")) and lbl:
-                    gid = self.build_recs_and_reconcile(lbl, top['id'], "group")
+                    gid = self.build_recs_and_reconcile(lbl, "group")
                 if gid:
                     fetchid = gid.rsplit("/", 1)[-1]
                     frec = self.get_reference(fetchid)

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -422,6 +422,7 @@ class LcnafMapper(LcMapper):
         # reconrec returns URI
 
         rec = {
+            "id" : txt
             "type": "",
             "identified_by": [
                 {

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -422,7 +422,7 @@ class LcnafMapper(LcMapper):
         # reconrec returns URI
 
         rec = {
-            "id" : txt
+            "id" : ""
             "type": "",
             "identified_by": [
                 {

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -488,385 +488,13 @@ class LcnafMapper(LcMapper):
             # Now fill out the details from RWO
             # if we have one
 
-            if "madsrdf:identifiesRWO" in new:
-                rwo = new["madsrdf:identifiesRWO"]
-                if type(rwo) == list:
-                    rwo = rwo[0]
-                    print(rwo)
-
-                # Name is rdfs:label, and copied from concept
-                if "madsrdf:gender" in rwo:
-                    g = rwo["madsrdf:gender"]
-                    if type(g) == list:
-                        g = g[0]
-
-                    if "rdfs:label" in g:
-                        txt = g["rdfs:label"]
-                        if type(txt) == list:
-                            txt = txt[0]
-                        if type(txt) == dict:
-                            txt = txt.get("@value", "")
-                    elif "@id" in g:
-                        gdr = g["@id"]
-                        if gdr in self.lc_female_uris:
-                            txt = "female"
-                        elif gdr in self.lc_male_uris:
-                            txt = "male"
-                        else:
-                            # print(f"*** [{recid}] Unknown gender id: {g}")
-                            txt = ""
-                    else:
-                        # print(f"*** [{recid}] Unknown gender format: {g}")
-                        txt = ""
-
-                    # FIXME: Actually make use of the transgender URIs
-                    # AAT terms
-
-                    txt = txt.strip().lower()
-                    if txt.startswith("("):
-                        # "(something) value"
-                        txt = txt.split(" ")[-1]
-                    if txt in ["male", "males", "men", "man"]:
-                        gender = vocab.instances["male"]
-                    elif txt in ["female", "females", "woman", "women"]:
-                        gender = vocab.instances["female"]
-                    else:
-                        # print(f"*** [{recid}] Unknown gender: {txt}")
-                        gender = None
-                    if gender:
-                        top.classified_as = gender
-
-                if "madsrdf:birthDate" in rwo:
-                    print("got birthdate at line 539")
-                    #'madsrdf:birthDate': {'@type': 'http://id.loc.gov/datatypes/edtf/EDTF', '@value': '1757-11-28'}
-                    txt = ""
-                    bd = rwo["madsrdf:birthDate"]
-                    if type(bd) == list:
-                        bd = bd[0]
-                    if type(bd) == dict:
-                        if "rdfs:label" in bd:
-                            txt = bd["rdfs:label"]
-                            if type(txt) == list:
-                                txt = txt[0]
-                            if type(txt) == dict:
-                                txt = txt["@value"]
-                        elif "@value" in bd:
-                            txt = bd["@value"]
-                    elif type(bd) == str:
-                        txt = bd
-                    txt = txt.replace("(edtf) ", "").strip()
-                    try:
-                        (bdate, edate) = make_datetime(txt)
-                    except:
-                        # No date found
-                        # print(f"*** [{recid}] Unparsable birthDate: {txt}")
-                        bdate = None
-                    if bdate:
-                        birth = model.Birth()
-                        ts = model.TimeSpan()
-                        ts.begin_of_the_begin = bdate
-                        ts.end_of_the_end = edate
-                        ts.identified_by = vocab.DisplayName(content=txt)
-                        birth.timespan = ts
-                        top.born = birth
-
-                if "madsrdf:birthPlace" in rwo:
-                    bp = rwo["madsrdf:birthPlace"]
-                    if type(bp) == list:
-                        bp = bp[0]
-                    if type(bp) == dict:
-                        bpid = bp.get("@id", "")
-                    if type(bp) == str:
-                        bp = {"rdfs:label": bp}
-                    if "madsrdf:authoritativeLabel" in bp:
-                        lbl = bp["madsrdf:authoritativeLabel"]
-                    elif "rdfs:label" in bp:
-                        lbl = bp["rdfs:label"]
-                    else:
-                        lbl = ""
-                    if type(lbl) == list:
-                        lbl = lbl[0]
-                    if type(lbl) == dict:
-                        lbl = lbl.get("@value", "")
-
-                    txt = lbl.strip()
-                    if txt and "(" in txt:
-                        txt = re.sub(r'^\(.*?\)\s*', '', txt)
-                    if txt:
-                        if not bpid or bpid.startswith("_:"):
-                            bpid = self.build_recs_and_reconcile(txt, "place")
-                    if bpid:
-                        # bpid is full uri
-                        src, ident = self.config["all_configs"].split_uri(bpid)
-                        where = src["mapper"].get_reference(ident)
-                        if where and where.__class__ == model.Place:
-                            if not hasattr(top, "born"):
-                                birth = model.Birth()
-                                top.born = birth
-                            birth.took_place_at = where
-
-                if "madsrdf:deathDate" in rwo:
-                    txt = ""
-                    dd = rwo["madsrdf:deathDate"]
-                    if type(dd) == list:
-                        dd = dd[0]
-                    if type(dd) == dict:
-                        if "rdfs:label" in dd:
-                            txt = dd["rdfs:label"]
-                            if type(txt) == list:
-                                txt = txt[0]
-                            if type(txt) == dict:
-                                txt = txt["@value"]
-                        elif "@value" in dd:
-                            txt = dd["@value"]
-                    elif type(dd) == str:
-                        txt = dd
-                    txt = txt.replace("(edtf) ", "").strip()
-
-                    try:
-                        (bdate, edate) = make_datetime(txt)
-                    except:
-                        # print(f"*** [{recid}] Unparsable deathDate: {txt}")
-                        bdate = None
-                    if bdate:
-                        death = model.Death()
-                        ts = model.TimeSpan()
-                        ts.begin_of_the_begin = bdate
-                        ts.end_of_the_end = edate
-                        ts.identified_by = vocab.DisplayName(content=txt)
-                        death.timespan = ts
-                        top.died = death
-
-                if "madsrdf:deathPlace" in rwo:
-                    bp = rwo["madsrdf:deathPlace"]
-                    if type(bp) == list:
-                        bp = bp[0]
-                    if type(bp) == dict:
-                        dpid = bp.get("@id", "")
-                    if type(bp) == str:
-                        bp = {"rdfs:label": bp}
-                    if "madsrdf:authoritativeLabel" in bp:
-                        lbl = bp["madsrdf:authoritativeLabel"]
-                    elif "rdfs:label" in bp:
-                        lbl = bp["rdfs:label"]
-                    if type(lbl) == list:
-                        lbl = lbl[0]
-                    if type(lbl) == dict:
-                        lbl = lbl.get("@value", "")
-                    txt = lbl.strip()
-                    if txt and "(" in txt:
-                        txt = re.sub(r'^\(.*?\)\s*', '', txt)
-                    if txt:
-                        if not dpid or dpid.startswith("_:"):
-                            dpid = self.build_recs_and_reconcile(txt, "place")
-                    if dpid:
-                        # dpid is full uri
-                        src, ident = self.config["all_configs"].split_uri(dpid)
-                        where = src["mapper"].get_reference(ident)
-                        if where and where.__class__ == model.Place:
-                            if not hasattr(top, "died"):
-                                death = model.Death()
-                                top.died = death
-                            death.took_place_at = where
-
-                if "madsrdf:fieldOfActivity" in rwo:
-                    # fieldOfActivity --> professional activity
-                    # activityStartDate
-                    # activityEndDate
-
-                    foa = rwo["madsrdf:fieldOfActivity"]
-                    if type(foa) != list:
-                        foa = [foa]
-                    for f in foa:
-                        fid = f["@id"]
-                        al = ""
-                        if "madsrdf:authoritativeLabel" in f:
-                            al = f["madsrdf:authoritativeLabel"]
-                        elif "rdfs:label" in f:
-                            al = f["rdfs:label"]
-                        if type(al) == list:
-                            al = al[0]
-                        if type(al) == dict:
-                            al = al.get("@value", "")
-                        if fid.startswith("_:"):
-                            if al.startswith("("):
-                                al = re.sub(r'^\(.*?\)\s*', '', al)
-                            fid = self.build_recs_and_reconcile(al, "concept")
-                        if fid:
-                            if "authorities/names" in fid:
-                                continue
-                            act = vocab.Active()
-                            act.classified_as = model.Type(ident=fid, label=al)
-                            top.carried_out = act
-
-                    if "madsrdf:activityStartDate" in rwo:
-                        print(
-                            f"LCNAF start activity: {rwo['madsrdf:activityStartDate']}"
-                        )
-
-                    if "madsrdf:activityEndDate" in rwo:
-                        print(f"LCNAF end activity: {rwo['madsrdf:activityEndDate']}")
-
-                if "madsrdf:occupation" in rwo:
-                    # occupation --> classified_as
-                    occ = rwo["madsrdf:occupation"]
-                    if type(occ) != list:
-                        occ = [occ]
-                    for o in occ:
-                        oid = o["@id"]
-                        al = ""
-                        if "madsrdf:authoritativeLabel" in o:
-                            al = o["madsrdf:authoritativeLabel"]
-                        elif "rdfs:label" in o:
-                            al = o["rdfs:label"]
-                        if type(al) == list:
-                            al = al[0]
-                        if type(al) == dict:
-                            al = al.get("@value", "")
-                        if oid.startswith("_:"):
-                            if al.startswith("("):
-                                al = re.sub(r'^\(.*?\)\s*', '', al)
-                            oid = self.build_recs_and_reconcile(al, "concept")
-                        if oid and "names" in oid:
-                            # actually member_of
-                            top.member_of = model.Group(ident=oid, label=al)
-                        elif oid:
-                            cxn = model.Type(ident=oid, label=al)
-                            cxn.classified_as = model.Type(
-                                ident="http://vocab.getty.edu/aat/300435108",
-                                label="Occupation",
-                            )
-                            top.classified_as = cxn
-
-                if "madsrdf:hasAffiliation" in rwo:
-                    # affiliation to organization = member_of Group
-                    orgs = []
-                    affs = rwo["madsrdf:hasAffiliation"]
-                    if type(affs) != list:
-                        affs = [affs]
-                    for aff in affs:
-                        if "madsrdf:organization" in aff:
-                            # affiliation as member_of
-                            org = aff["madsrdf:organization"]
-                            if type(org) == list:
-                                orgs.extend(org)
-                            else:
-                                orgs.append(org)
-                        elif "madsrdf:hasAffiliationAddress" in aff:
-                            # affiliation as ... self?
-                            affa = aff["madsrdf:hasAffiliationAddress"]
-                            if type(affa) != list:
-                                affa = [affa]
-                            for add in affa:
-                                # streetAddress, city, state, postcode
-                                bits = []
-                                for x in ["streetAddress", "city", "state", "postcode"]:
-                                    if f"madsrdf:{x}" in add:
-                                        bit = add[f"madsrdf:{x}"]
-                                        if type(bit) == list:
-                                            bit = bit[0]
-                                        if type(bit) == dict:
-                                            bit = bit["@value"]
-                                        bits.append(bit)
-                                if bits:
-                                    # print(f"contact bits: {bits}")
-                                    cp = vocab.StreetAddress(content=", ".join(bits))
-                                    if topcls in [model.Group, model.Person]:
-                                        top.contact_point = cp
-
-                    for o in orgs:
-                        lbl = ""
-                        if "madsrdf:authoritativeLabel" in o:
-                            lbl = o["madsrdf:authoritativeLabel"]
-                        elif "rdfs:label" in o:
-                            lbl = o["rdfs:label"]
-                        if type(lbl) == list:
-                            lbl = lbl[0]
-                        if type(lbl) == dict:
-                            lbl = lbl["@value"]
-                        if lbl.startswith("("):
-                            lbl = re.sub(r'^\(.*?\)\s*', '', lbl)
-                        gid = o.get("@id", "")
-
-                        if (gid == "" or gid.startswith("_")) and lbl:
-                            gid = self.build_recs_and_reconcile(lbl, "group")
-                        if gid:
-                            fetchid = gid.rsplit("/", 1)[-1]
-                            frec = self.get_reference(fetchid)
-                            if frec.__class__ == model.Group:
-                                if topcls in [model.Group, model.Person]:
-                                    top.member_of = frec
-                                elif topcls in [model.Activity]:
-                                    top.carried_out_by = frec
-
-                if "madsrdf:hasCorporateParentAuthority" in rwo:
-                    print(f"got parent: {rwo['madsrdf:hasCorporateParentAuthority']}")
-                    pass
-
-                if "madsrdf:establishDate" in rwo:
-                    txt = ""
-                    dd = rwo["madsrdf:establishDate"]
-                    if type(dd) == list:
-                        dd = dd[0]
-                    if type(dd) == dict:
-                        if "rdfs:label" in dd:
-                            txt = dd["rdfs:label"]
-                            if type(txt) == list:
-                                txt = txt[0]
-                            if type(txt) == dict:
-                                txt = txt["@value"]
-                        elif "@value" in dd:
-                            txt = dd["@value"]
-                    elif type(dd) == str:
-                        txt = dd
-                    txt = txt.replace("(edtf) ", "").strip()
-                    try:
-                        (bdate, edate) = make_datetime(txt)
-                    except:
-                        # print(f"*** [{recid}] Unparsable establishDate: {txt}")
-                        bdate = None
-                    if bdate:
-                        frm = model.Formation()
-                        ts = model.TimeSpan()
-                        ts.begin_of_the_begin = bdate
-                        ts.end_of_the_end = edate
-                        ts.identified_by = vocab.DisplayName(content=txt)
-                        frm.timespan = ts
-                        top.formed_by = frm
-                if "madsrdf:terminateDate" in rwo:
-                    txt = ""
-                    dd = rwo["madsrdf:terminateDate"]
-                    if type(dd) == list:
-                        dd = dd[0]
-                    if type(dd) == dict:
-                        if "rdfs:label" in dd:
-                            txt = dd["rdfs:label"]
-                            if type(txt) == list:
-                                txt = txt[0]
-                            if type(txt) == dict:
-                                txt = txt["@value"]
-                        elif "@value" in dd:
-                            txt = dd["@value"]
-                    elif type(dd) == str:
-                        txt = dd
-                    txt = txt.replace("(edtf) ", "").strip()
-                    try:
-                        (bdate, edate) = make_datetime(txt)
-                    except:
-                        # print(f"*** [{recid}] Unparsable terminateDate: {txt}")
-                        bdate = None
-                    if bdate:
-                        dss = model.Dissolution()
-                        ts = model.TimeSpan()
-                        ts.begin_of_the_begin = bdate
-                        ts.end_of_the_end = edate
-                        ts.identified_by = vocab.DisplayName(content=txt)
-                        dss.timespan = ts
-                        top.dissolved_by = dss
-
-                # if 'madsrdf:associatedLanguage' in rwo:
-                # if 'madsrdf:associatedLocale' in rwo:
-                # Could use AttributeAssignment pattern
+        if "madsrdf:identifiesRWO" in new:
+            rwo = new["madsrdf:identifiesRWO"]
+            if type(rwo) == list:
+                for r in rwo:
+                    self.process_rwo(r, top)
+            elif type(rwo) == dict:
+                self.process_rwo(rwo, top)
 
             if top.type == "Person":
                 okay = test_birth_death(top)
@@ -878,5 +506,375 @@ class LcnafMapper(LcMapper):
                         # This shouldn't ever happen, but not going to die on the hill
                         pass
 
+
         js = model.factory.toJSON(top)
         return {"identifier": record["identifier"], "data": js, "source": self.name}
+
+    def process_rwo(self, rwo, top):
+        if "madsrdf:gender" in rwo:
+            g = rwo["madsrdf:gender"]
+            if type(g) == list:
+                g = g[0]
+
+            if "rdfs:label" in g:
+                txt = g["rdfs:label"]
+                if type(txt) == list:
+                    txt = txt[0]
+                if type(txt) == dict:
+                    txt = txt.get("@value", "")
+            elif "@id" in g:
+                gdr = g["@id"]
+                if gdr in self.lc_female_uris:
+                    txt = "female"
+                elif gdr in self.lc_male_uris:
+                    txt = "male"
+                else:
+                    # print(f"*** [{recid}] Unknown gender id: {g}")
+                    txt = ""
+            else:
+                # print(f"*** [{recid}] Unknown gender format: {g}")
+                txt = ""
+
+            # FIXME: Actually make use of the transgender URIs
+            # AAT terms
+
+            txt = txt.strip().lower()
+            if txt.startswith("("):
+                # "(something) value"
+                txt = txt.split(" ")[-1]
+            if txt in ["male", "males", "men", "man"]:
+                gender = vocab.instances["male"]
+            elif txt in ["female", "females", "woman", "women"]:
+                gender = vocab.instances["female"]
+            else:
+                # print(f"*** [{recid}] Unknown gender: {txt}")
+                gender = None
+            if gender:
+                top.classified_as = gender
+
+        if "madsrdf:birthDate" in rwo:
+            txt = ""
+            bd = rwo["madsrdf:birthDate"]
+            if type(bd) == list:
+                bd = bd[0]
+            if type(bd) == dict:
+                if "rdfs:label" in bd:
+                    txt = bd["rdfs:label"]
+                    if type(txt) == list:
+                        txt = txt[0]
+                    if type(txt) == dict:
+                        txt = txt["@value"]
+                elif "@value" in bd:
+                    txt = bd["@value"]
+            elif type(bd) == str:
+                txt = bd
+            txt = txt.replace("(edtf) ", "").strip()
+            try:
+                (bdate, edate) = make_datetime(txt)
+            except:
+                # No date found
+                # print(f"*** [{recid}] Unparsable birthDate: {txt}")
+                bdate = None
+            if bdate:
+                birth = model.Birth()
+                ts = model.TimeSpan()
+                ts.begin_of_the_begin = bdate
+                ts.end_of_the_end = edate
+                ts.identified_by = vocab.DisplayName(content=txt)
+                birth.timespan = ts
+                top.born = birth
+
+        if "madsrdf:birthPlace" in rwo:
+            bp = rwo["madsrdf:birthPlace"]
+            if type(bp) == list:
+                bp = bp[0]
+            if type(bp) == dict:
+                bpid = bp.get("@id", "")
+            if type(bp) == str:
+                bp = {"rdfs:label": bp}
+            if "madsrdf:authoritativeLabel" in bp:
+                lbl = bp["madsrdf:authoritativeLabel"]
+            elif "rdfs:label" in bp:
+                lbl = bp["rdfs:label"]
+            else:
+                lbl = ""
+            if type(lbl) == list:
+                lbl = lbl[0]
+            if type(lbl) == dict:
+                lbl = lbl.get("@value", "")
+
+            txt = lbl.strip()
+            if txt and "(" in txt:
+                txt = re.sub(r'^\(.*?\)\s*', '', txt)
+            if txt:
+                if not bpid or bpid.startswith("_:"):
+                    bpid = self.build_recs_and_reconcile(txt, "place")
+            if bpid:
+                # bpid is full uri
+                src, ident = self.config["all_configs"].split_uri(bpid)
+                where = src["mapper"].get_reference(ident)
+                if where and where.__class__ == model.Place:
+                    if not hasattr(top, "born"):
+                        birth = model.Birth()
+                        top.born = birth
+                    birth.took_place_at = where
+
+        if "madsrdf:deathDate" in rwo:
+            txt = ""
+            dd = rwo["madsrdf:deathDate"]
+            if type(dd) == list:
+                dd = dd[0]
+            if type(dd) == dict:
+                if "rdfs:label" in dd:
+                    txt = dd["rdfs:label"]
+                    if type(txt) == list:
+                        txt = txt[0]
+                    if type(txt) == dict:
+                        txt = txt["@value"]
+                elif "@value" in dd:
+                    txt = dd["@value"]
+            elif type(dd) == str:
+                txt = dd
+            txt = txt.replace("(edtf) ", "").strip()
+
+            try:
+                (bdate, edate) = make_datetime(txt)
+            except:
+                # print(f"*** [{recid}] Unparsable deathDate: {txt}")
+                bdate = None
+            if bdate:
+                death = model.Death()
+                ts = model.TimeSpan()
+                ts.begin_of_the_begin = bdate
+                ts.end_of_the_end = edate
+                ts.identified_by = vocab.DisplayName(content=txt)
+                death.timespan = ts
+                top.died = death
+
+        if "madsrdf:deathPlace" in rwo:
+            bp = rwo["madsrdf:deathPlace"]
+            if type(bp) == list:
+                bp = bp[0]
+            if type(bp) == dict:
+                dpid = bp.get("@id", "")
+            if type(bp) == str:
+                bp = {"rdfs:label": bp}
+            if "madsrdf:authoritativeLabel" in bp:
+                lbl = bp["madsrdf:authoritativeLabel"]
+            elif "rdfs:label" in bp:
+                lbl = bp["rdfs:label"]
+            if type(lbl) == list:
+                lbl = lbl[0]
+            if type(lbl) == dict:
+                lbl = lbl.get("@value", "")
+            txt = lbl.strip()
+            if txt and "(" in txt:
+                txt = re.sub(r'^\(.*?\)\s*', '', txt)
+            if txt:
+                if not dpid or dpid.startswith("_:"):
+                    dpid = self.build_recs_and_reconcile(txt, "place")
+            if dpid:
+                # dpid is full uri
+                src, ident = self.config["all_configs"].split_uri(dpid)
+                where = src["mapper"].get_reference(ident)
+                if where and where.__class__ == model.Place:
+                    if not hasattr(top, "died"):
+                        death = model.Death()
+                        top.died = death
+                    death.took_place_at = where
+
+        if "madsrdf:fieldOfActivity" in rwo:
+            # fieldOfActivity --> professional activity
+            # activityStartDate
+            # activityEndDate
+
+            foa = rwo["madsrdf:fieldOfActivity"]
+            if type(foa) != list:
+                foa = [foa]
+            for f in foa:
+                fid = f["@id"]
+                al = ""
+                if "madsrdf:authoritativeLabel" in f:
+                    al = f["madsrdf:authoritativeLabel"]
+                elif "rdfs:label" in f:
+                    al = f["rdfs:label"]
+                if type(al) == list:
+                    al = al[0]
+                if type(al) == dict:
+                    al = al.get("@value", "")
+                if fid.startswith("_:"):
+                    if al.startswith("("):
+                        al = re.sub(r'^\(.*?\)\s*', '', al)
+                    fid1 = self.build_recs_and_reconcile(al, "concept")
+                if fid1:
+                    if "authorities/names" in fid1:
+                        continue
+                    act = vocab.Active()
+                    act.classified_as = model.Type(ident=fid1, label=al)
+                    top.carried_out = act
+        if "madsrdf:activityStartDate" in rwo:
+            print(f"LCNAF start activity: {rwo['madsrdf:activityStartDate']}")
+        if "madsrdf:activityEndDate" in rwo:
+            print(f"LCNAF end activity: {rwo['madsrdf:activityEndDate']}")
+
+        if "madsrdf:occupation" in rwo:
+            # occupation --> classified_as
+            occ = rwo["madsrdf:occupation"]
+            if type(occ) != list:
+                occ = [occ]
+            for o in occ:
+                oid = o["@id"]
+                al = ""
+                if "madsrdf:authoritativeLabel" in o:
+                    al = o["madsrdf:authoritativeLabel"]
+                elif "rdfs:label" in o:
+                    al = o["rdfs:label"]
+                if type(al) == list:
+                    al = al[0]
+                if type(al) == dict:
+                    al = al.get("@value", "")
+                if oid.startswith("_:"):
+                    if al.startswith("("):
+                        al = re.sub(r'^\(.*?\)\s*', '', al)
+                    oid = self.build_recs_and_reconcile(al, "concept")
+                if oid and "names" in oid:
+                    # actually member_of
+                    top.member_of = model.Group(ident=oid, label=al)
+                elif oid:
+                    cxn = model.Type(ident=oid, label=al)
+                    cxn.classified_as = model.Type(
+                        ident="http://vocab.getty.edu/aat/300435108",
+                        label="Occupation",
+                        )
+                    top.classified_as = cxn
+
+        if "madsrdf:hasAffiliation" in rwo:
+            # affiliation to organization = member_of Group
+            orgs = []
+            affs = rwo["madsrdf:hasAffiliation"]
+            if type(affs) != list:
+                affs = [affs]
+            for aff in affs:
+                if "madsrdf:organization" in aff:
+                    # affiliation as member_of
+                    org = aff["madsrdf:organization"]
+                    if type(org) == list:
+                        orgs.extend(org)
+                    else:
+                        orgs.append(org)
+                elif "madsrdf:hasAffiliationAddress" in aff:
+                    # affiliation as ... self?
+                    affa = aff["madsrdf:hasAffiliationAddress"]
+                    if type(affa) != list:
+                        affa = [affa]
+                    for add in affa:
+                        # streetAddress, city, state, postcode
+                        bits = []
+                        for x in ["streetAddress", "city", "state", "postcode"]:
+                            if f"madsrdf:{x}" in add:
+                                bit = add[f"madsrdf:{x}"]
+                                if type(bit) == list:
+                                    bit = bit[0]
+                                if type(bit) == dict:
+                                    bit = bit["@value"]
+                                bits.append(bit)
+                        if bits:
+                            # print(f"contact bits: {bits}")
+                            cp = vocab.StreetAddress(content=", ".join(bits))
+                            if topcls in [model.Group, model.Person]:
+                                top.contact_point = cp
+
+            for o in orgs:
+                lbl = ""
+                if "madsrdf:authoritativeLabel" in o:
+                    lbl = o["madsrdf:authoritativeLabel"]
+                elif "rdfs:label" in o:
+                    lbl = o["rdfs:label"]
+                if type(lbl) == list:
+                    lbl = lbl[0]
+                if type(lbl) == dict:
+                    lbl = lbl["@value"]
+                if lbl.startswith("("):
+                    lbl = re.sub(r'^\(.*?\)\s*', '', lbl)
+                gid = o.get("@id", "")
+
+                if (gid == "" or gid.startswith("_")) and lbl:
+                    gid = self.build_recs_and_reconcile(lbl, "group")
+                if gid:
+                    fetchid = gid.rsplit("/", 1)[-1]
+                    frec = self.get_reference(fetchid)
+                    if frec.__class__ == model.Group:
+                        if topcls in [model.Group, model.Person]:
+                            top.member_of = frec
+                        elif topcls in [model.Activity]:
+                            top.carried_out_by = frec
+
+        if "madsrdf:hasCorporateParentAuthority" in rwo:
+            print(f"got parent: {rwo['madsrdf:hasCorporateParentAuthority']}")
+            pass
+
+        if "madsrdf:establishDate" in rwo:
+            txt = ""
+            dd = rwo["madsrdf:establishDate"]
+            if type(dd) == list:
+                dd = dd[0]
+            if type(dd) == dict:
+                if "rdfs:label" in dd:
+                    txt = dd["rdfs:label"]
+                    if type(txt) == list:
+                        txt = txt[0]
+                    if type(txt) == dict:
+                        txt = txt["@value"]
+                elif "@value" in dd:
+                    txt = dd["@value"]
+            elif type(dd) == str:
+                txt = dd
+            txt = txt.replace("(edtf) ", "").strip()
+            try:
+                (bdate, edate) = make_datetime(txt)
+            except:
+                # print(f"*** [{recid}] Unparsable establishDate: {txt}")
+                bdate = None
+            if bdate:
+                frm = model.Formation()
+                ts = model.TimeSpan()
+                ts.begin_of_the_begin = bdate
+                ts.end_of_the_end = edate
+                ts.identified_by = vocab.DisplayName(content=txt)
+                frm.timespan = ts
+                top.formed_by = frm
+        if "madsrdf:terminateDate" in rwo:
+            txt = ""
+            dd = rwo["madsrdf:terminateDate"]
+            if type(dd) == list:
+                dd = dd[0]
+            if type(dd) == dict:
+                if "rdfs:label" in dd:
+                    txt = dd["rdfs:label"]
+                    if type(txt) == list:
+                        txt = txt[0]
+                    if type(txt) == dict:
+                        txt = txt["@value"]
+                elif "@value" in dd:
+                    txt = dd["@value"]
+            elif type(dd) == str:
+                txt = dd
+            txt = txt.replace("(edtf) ", "").strip()
+            try:
+                (bdate, edate) = make_datetime(txt)
+            except:
+                # print(f"*** [{recid}] Unparsable terminateDate: {txt}")
+                bdate = None
+            if bdate:
+                dss = model.Dissolution()
+                ts = model.TimeSpan()
+                ts.begin_of_the_begin = bdate
+                ts.end_of_the_end = edate
+                ts.identified_by = vocab.DisplayName(content=txt)
+                dss.timespan = ts
+                top.dissolved_by = dss
+
+        # if 'madsrdf:associatedLanguage' in rwo:
+        # if 'madsrdf:associatedLocale' in rwo:
+        # Could use AttributeAssignment pattern
+        

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -454,15 +454,21 @@ class LcnafMapper(LcMapper):
             if type(record) == list:
                 # BAD CALLER!
                 rec = record
+        if rec:
+            print("got rec at line 451")
         if not rec["@graph"] or rec["@graph"] == {}:
+            print("returning none at line 457")
             return None
 
         new = LcMapper.transform(self, record, rectype, reference)
 
         if new and not rectype:
             rectype = self.guess_type(new)
+            print("got rectype at line 467")
         if not new or not rectype:
+            print("returning none at line 468")
             return None
+
 
         recid = new["@id"]
         topcls = getattr(model, rectype)
@@ -535,6 +541,7 @@ class LcnafMapper(LcMapper):
                         top.classified_as = gender
 
                 if "madsrdf:birthDate" in rwo:
+                    #'madsrdf:birthDate': {'@type': 'http://id.loc.gov/datatypes/edtf/EDTF', '@value': '1757-11-28'}
                     txt = ""
                     bd = rwo["madsrdf:birthDate"]
                     if type(bd) == list:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -489,10 +489,11 @@ class LcnafMapper(LcMapper):
             # if we have one
 
             if "madsrdf:identifiesRWO" in new:
-                print("got rwo at line 491")
                 rwo = new["madsrdf:identifiesRWO"]
+                print(f"got rwo {rwo}")
                 if type(rwo) == list:
                     rwo = rwo[0]
+                    print("rwo was a list")
 
                 # Name is rdfs:label, and copied from concept
                 if "madsrdf:gender" in rwo:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -705,12 +705,12 @@ class LcnafMapper(LcMapper):
                 if fid.startswith("_:"):
                     if al.startswith("("):
                         al = re.sub(r'^\(.*?\)\s*', '', al)
-                    fid1 = self.build_recs_and_reconcile(al, "concept")
-                if fid1:
-                    if "authorities/names" in fid1:
+                    fid = self.build_recs_and_reconcile(al, "concept")
+                if fid:
+                    if "authorities/names" in fid:
                         continue
                     act = vocab.Active()
-                    act.classified_as = model.Type(ident=fid1, label=al)
+                    act.classified_as = model.Type(ident=fid, label=al)
                     top.carried_out = act
         if "madsrdf:activityStartDate" in rwo:
             print(f"LCNAF start activity: {rwo['madsrdf:activityStartDate']}")

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -418,11 +418,11 @@ class LcnafMapper(LcMapper):
         else:
             self.parenthetical_places = {}
 
-    def build_recs_and_reconcile(self, txt, rectype=""):
+    def build_recs_and_reconcile(self, txt, ident, rectype=""):
         # reconrec returns URI
 
         rec = {
-            "id" : ""
+            "id" : ident
             "type": "",
             "identified_by": [
                 {
@@ -609,7 +609,7 @@ class LcnafMapper(LcMapper):
                 txt = re.sub(r'^\(.*?\)\s*', '', txt)
             if txt:
                 if not bpid or bpid.startswith("_:"):
-                    bpid = self.build_recs_and_reconcile(txt, "place")
+                    bpid = self.build_recs_and_reconcile(txt, top['id'], "place")
             if bpid:
                 # bpid is full uri
                 src, ident = self.config["all_configs"].split_uri(bpid)
@@ -673,7 +673,7 @@ class LcnafMapper(LcMapper):
                 txt = re.sub(r'^\(.*?\)\s*', '', txt)
             if txt:
                 if not dpid or dpid.startswith("_:"):
-                    dpid = self.build_recs_and_reconcile(txt, "place")
+                    dpid = self.build_recs_and_reconcile(txt, top['id'], "place")
             if dpid:
                 # dpid is full uri
                 src, ident = self.config["all_configs"].split_uri(dpid)
@@ -706,7 +706,7 @@ class LcnafMapper(LcMapper):
                 if fid.startswith("_:"):
                     if al.startswith("("):
                         al = re.sub(r'^\(.*?\)\s*', '', al)
-                    fid1 = self.build_recs_and_reconcile(al, "concept")
+                    fid1 = self.build_recs_and_reconcile(al, top['id'], "concept")
                 if fid1:
                     if "authorities/names" in fid1:
                         continue
@@ -737,7 +737,7 @@ class LcnafMapper(LcMapper):
                 if oid.startswith("_:"):
                     if al.startswith("("):
                         al = re.sub(r'^\(.*?\)\s*', '', al)
-                    oid = self.build_recs_and_reconcile(al, "concept")
+                    oid = self.build_recs_and_reconcile(al, top['id'], "concept")
                 if oid and "names" in oid:
                     # actually member_of
                     top.member_of = model.Group(ident=oid, label=al)
@@ -800,7 +800,7 @@ class LcnafMapper(LcMapper):
                 gid = o.get("@id", "")
 
                 if (gid == "" or gid.startswith("_")) and lbl:
-                    gid = self.build_recs_and_reconcile(lbl, "group")
+                    gid = self.build_recs_and_reconcile(lbl, top['id'], "group")
                 if gid:
                     fetchid = gid.rsplit("/", 1)[-1]
                     frec = self.get_reference(fetchid)


### PR DESCRIPTION
ignore non-descriptive branch name.
discovered a bug in LC Mapper that wasn't processing LCNAF props if RWO was a list--rwo[0] was just the first dictionary in the list, it wouldn't find any of the props. This works for dict and list RWO.

updated and had to update the base reconciler to check for rec['id'] first because of the fake reconrecs built in LCMapper.