### PR TITLE
fix dnb images

### DIFF
--- a/pipeline/sources/libraries/dnb/mapper.py
+++ b/pipeline/sources/libraries/dnb/mapper.py
@@ -287,7 +287,7 @@ class DnbMapper(Mapper):
         elif typ == "place":
             topcls = model.Place
         else:
-            print(f"Unknown @type in dnb {rec['@id']}: {typ}")
+            print(f"Unknown @type in dnb {data['@id']}: {typ}")
             return None
         return topcls
 
@@ -475,6 +475,20 @@ class DnbMapper(Mapper):
                     continue
                 lo.digitally_carried_by = do
                 top.subject_of = lo
+
+        if 'depiction' in rec:
+            dep = rec['depiction']
+            if type(dep) != list:
+                dep = [dep]
+            for d in dep:
+                # Image is actually in @id
+                jpg = d['@id']
+                jpg = jpg.replace(" ", "_")
+                do = vocab.DigitalImage(label=f"Digital Image of {pn}")
+                vi = model.VisualItem(label=f"Appearance of {pn}")
+                do.access_point = model.DigitalObject(ident=jpg)
+                vi.digitally_shown_by = do
+                top.representation = vi
 
         if 'sameAs' in rec:
             sa = rec['sameAs']

--- a/pipeline/sources/libraries/dnb/mapper.py
+++ b/pipeline/sources/libraries/dnb/mapper.py
@@ -486,6 +486,8 @@ class DnbMapper(Mapper):
                 # Image is actually in @id
                 jpg = d['@id']
                 jpg = jpg.replace(" ", "_")
+                if "%20" in jpg:
+                    jpg = jpg.replace("%20","_")
                 do = vocab.DigitalImage(label=f"Digital Image of {pn}")
                 vi = model.VisualItem(label=f"Appearance of {pn}")
                 do.access_point = model.DigitalObject(ident=jpg)

--- a/pipeline/sources/libraries/dnb/mapper.py
+++ b/pipeline/sources/libraries/dnb/mapper.py
@@ -476,19 +476,6 @@ class DnbMapper(Mapper):
                 lo.digitally_carried_by = do
                 top.subject_of = lo
 
-        if 'depiction' in rec:
-            dep = rec['depiction']
-            if type(dep) != list:
-                dep = [dep]
-            for d in dep:
-                # Image is actually in @id
-                jpg = d['@id']
-                do = vocab.DigitalImage(label=f"Digital Image of {pn}")
-                vi = model.VisualItem(label=f"Appearance of {pn}")
-                do.access_point = model.DigitalObject(ident=jpg)
-                vi.digitally_shown_by = do
-                top.representation = vi
-
         if 'sameAs' in rec:
             sa = rec['sameAs']
             try:

--- a/pipeline/sources/libraries/dnb/mapper.py
+++ b/pipeline/sources/libraries/dnb/mapper.py
@@ -286,6 +286,8 @@ class DnbMapper(Mapper):
             typ = 'group'
         elif typ == "place":
             topcls = model.Place
+        elif typ == "event":
+            topcls = model.Event
         else:
             print(f"Unknown @type in dnb {data['@id']}: {typ}")
             return None

--- a/pipeline/sources/lux/final/mapper.py
+++ b/pipeline/sources/lux/final/mapper.py
@@ -71,6 +71,7 @@ class Cleaner(Mapper):
 
                 # Munge stupid wikimedia image URLs
                 if "commons.wikimedia.org/wiki/special:filepath" in apid.lower():
+                    wd_aps.append(apid.lower())
                     if apid.startswith("http:"):
                         apid = apid.replace("http://", "https://")
                     url, fn = apid.rsplit("/", 1)


### PR DESCRIPTION
aka why Cannes got two images
https://www.bugherd.com/projects/284041/tasks/2481

I initially just dropped the representation block from the DNB mapper, since they're 100% wikimedia links, but thought better of it--now there's a fix in the DNB mapper to match the Wikimedia url formatting, and the dupes will get thrown out at line 102 of the final mapper.

Also added line 74 to the final mapper, as wd_aps was never getting built. 
Also a bug in the DNB guesser is now fixed.

In some ways it is moot, as the front end isn't displaying images on Events yet, and when they do, they'll likely just pull the first one...but there were bugs that are now fixed :)