### PR TITLE
don't know how this happened!

### DIFF
--- a/pipeline/sources/lux/final/mapper.py
+++ b/pipeline/sources/lux/final/mapper.py
@@ -529,7 +529,7 @@ class Cleaner(Mapper):
         data = rec["data"]
 
         ### Deduplicate properties
-        propList = ["classified_as, represents, part_of, made_of, member_of"]
+        propList = ["classified_as", "represents", "part_of", "made_of", "member_of"]
         for p in propList:
             self.dedupe_properties(data, p)
 


### PR DESCRIPTION
but I found dedupe properties not working in a record and traced it back to here.
record in question that should have been deduped:
https://lux-front-tst.collections.yale.edu/view/person/280f4fa4-bb4a-4a87-85e6-b3295e348f0e
(nationality)