### PR TITLE
Pipeline121

### DIFF
--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -234,6 +234,8 @@ class LcMapper(Mapper):
                     if "madsrdf:variantLabel" in l:
                         if "@value" in l["madsrdf:variantLabel"]:
                             txt = l['madsrdf:variantLabel']['@value']
+                        else:
+                            txt = e['madsrdf:variantLabel']
                     else:
                         txt = None 
                     if "@id" in l:
@@ -258,7 +260,7 @@ class LcMapper(Mapper):
                         if "@value" in e["madsrdf:variantLabel"]:
                             txt = e['madsrdf:variantLabel']['@value']
                         else:
-                            print(e)
+                            txt = e['madsrdf:variantLabel']
                     else:
                         txt = None
                     if "@id" in e:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -257,6 +257,8 @@ class LcMapper(Mapper):
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:
                             txt = e['madsrdf:variantLabel']['@value']
+                        else:
+                            print(e)
                     else:
                         txt = None
                     if "@id" in e:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -235,15 +235,15 @@ class LcMapper(Mapper):
                     if "madsrdf:variantLabel" in l:
                         if "@value" in l["madsrdf:variantLabel"]:
                             txt = l['madsrdf:variantLabel']['@value']
-                            if "(" in txt:
-                                txt = re.sub(r"^\(.*?\)\s*", "", txt)
-                        else:
-                            txt = None 
+                    else:
+                        txt = None 
                     if "@id" in l:
                         lid = l['@id']
+                    else:
+                        lid = None
                     if txt and (not lid or lid.startswith("_:")):
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and lid.startswith("_:"):
+                    elif not txt and (not lid or lid.startswith("_:")):
                         rlid = None 
                     if rlid:
                         laters.append(rlid)
@@ -258,15 +258,15 @@ class LcMapper(Mapper):
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:
                             txt = e['madsrdf:variantLabel']['@value']
-                            if "(" in txt:
-                                txt = re.sub(r"^\(.*?\)\s*", "", txt)
-                        else:
-                            txt = None
+                    else:
+                        txt = None
                     if "@id" in e:
                         eid = e['@id']
+                    else:
+                        eid = None
                     if txt and (not eid or eid.startswith("_:")):
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and eid.startswith("_:"):
+                    elif not txt and (not eid or eid.startswith("_:")):
                         reid = None 
                     if reid:
                         earliers.append(reid)

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -257,6 +257,7 @@ class LcMapper(Mapper):
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]
+                print(earlier)
                 for e in earlier:
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -260,7 +260,6 @@ class LcMapper(Mapper):
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]
-                print(earlier)
                 for e in earlier:
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:
@@ -274,6 +273,7 @@ class LcMapper(Mapper):
                     else:
                         eid = None
                     if eid.startswith("_:") and txt:
+                        print(type(top).__name__)
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):
                         reid = None

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -268,7 +268,7 @@ class LcMapper(Mapper):
                     elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:
-                        earlier.append(reid)
+                        earliers.append(reid)
                 ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -257,7 +257,6 @@ class LcMapper(Mapper):
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]
-                print(earlier)
                 for e in earlier:
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:
@@ -266,13 +265,13 @@ class LcMapper(Mapper):
                             txt = e['madsrdf:variantLabel']
                     else:
                         txt = None
-                    print(txt)
                     if "@id" in e:
                         eid = e['@id']
                     else:
                         eid = None
                     if eid.startswith("_:") and txt:
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                        print(reid)
                     elif not txt and eid.startswith("_:"):
                         reid = None
                     else:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -228,7 +228,6 @@ class LcMapper(Mapper):
             laters = []
             later = new.get("madsrdf:hasLaterEstablishedForm", [])
             if later:
-                print(later)
                 if type(later) != list:
                     later = [later]
                 for l in later:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -228,7 +228,7 @@ class LcMapper(Mapper):
             laters = []
             later = new.get("madsrdf:hasLaterEstablishedForm", [])
             if later:
-                print(top['id'])
+                print(later)
                 if type(later) != list:
                     later = [later]
                 for l in later:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -233,6 +233,7 @@ class LcMapper(Mapper):
             if later:
                 if type(later) != list:
                     later = [later]
+                print(later)
                 for l in later:
                     if "madsrdf:variantLabel" in l:
                         if "@value" in l["madsrdf:variantLabel"]:
@@ -273,7 +274,6 @@ class LcMapper(Mapper):
                     else:
                         eid = None
                     if eid.startswith("_:") and txt:
-                        print(type(top).__name__)
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):
                         reid = None

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -236,7 +236,7 @@ class LcMapper(Mapper):
                     if "@id" in l:
                         lid = l['@id']
                     if txt and (not lid or lid.startswith("_:")):
-                        rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                        rlid = self.build_recs_and_reconcile(txt, str(type(top).__name__))
                     elif not txt and lid.startswith("_:"):
                         rlid = None 
                     if rlid:
@@ -258,9 +258,8 @@ class LcMapper(Mapper):
                             txt = None
                     if "@id" in e:
                         eid = e['@id']
-                    print(type(top).__name__)
                     if txt and (not eid or eid.startswith("_:")):
-                        reid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                        reid = self.build_recs_and_reconcile(txt, str(type(top).__name__))
                     elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -228,37 +228,14 @@ class LcMapper(Mapper):
 
 
         if top.__class__ != model.Group:
-            laters = []
             later = new.get("madsrdf:hasLaterEstablishedForm", [])
             if later:
                 if type(later) != list:
                     later = [later]
-                for l in later:
-                    if "madsrdf:variantLabel" in l:
-                        if "@value" in l["madsrdf:variantLabel"]:
-                            txt = l['madsrdf:variantLabel']['@value']
-                        else:
-                            txt = e['madsrdf:variantLabel']
-                    else:
-                        txt = None 
-                    if "@id" in l:
-                        lid = l['@id']
-                    else:
-                        lid = None
-                    if lid.startswith("_:") and txt:
-                        rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and lid.startswith("_:"):
-                        rlid = None
-                    else:
-                        rlid = lid
-                    if rlid:
-                        laters.append(rlid)
                 ex.extend(laters)
-
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             earliers = []
             if earlier:
-                print(earlier)
                 if type(earlier) != list:
                     earlier = [earlier]
                 for e in earlier:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -244,7 +244,7 @@ class LcMapper(Mapper):
                         lid = None
                     if txt and (not lid or lid.startswith("_:")):
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and (not lid or lid.startswith("_:")):
+                    elif not txt and lid.startswith("_:"):
                         rlid = None 
                     if rlid:
                         laters.append(rlid)
@@ -269,7 +269,7 @@ class LcMapper(Mapper):
                         eid = None
                     if txt and (not eid or eid.startswith("_:")):
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and (not eid or eid.startswith("_:")):
+                    elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:
                         earliers.append(reid)

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -249,7 +249,7 @@ class LcMapper(Mapper):
                 ex.extend(laters)
 
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
-            ealiers = []
+            earliers = []
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -246,6 +246,7 @@ class LcMapper(Mapper):
                     else:
                         lid = None
                     if lid.startswith("_:") and txt:
+                        print(txt)
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
                         rlid = None
@@ -258,7 +259,6 @@ class LcMapper(Mapper):
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             earliers = []
             if earlier:
-                print(earlier)
                 if type(earlier) != list:
                     earlier = [earlier]
                 for e in earlier:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -236,11 +236,11 @@ class LcMapper(Mapper):
                     if "@id" in l:
                         lid = l['@id']
                     if txt and (not lid or lid.startswith("_:")):
-                        lid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                        rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
-                        lid = None 
-                    if lid:
-                        laters.append(lid)
+                        rlid = None 
+                    if rlid:
+                        laters.append(rlid)
                 ex.extend(laters)
 
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
@@ -256,15 +256,15 @@ class LcMapper(Mapper):
                                 txt = re.sub(r"^\(.*?\)\s*", "", txt)
                         else:
                             txt = None
-                    print(txt) 
                     if "@id" in e:
                         eid = e['@id']
+                    print(type(top).__name__)
                     if txt and (not eid or eid.startswith("_:")):
-                        eid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                        reid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):
-                        eid = None 
-                    if eid:
-                        earlier.append(eid)
+                        reid = None 
+                    if reid:
+                        earlier.append(reid)
                 ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -228,6 +228,7 @@ class LcMapper(Mapper):
             laters = []
             later = new.get("madsrdf:hasLaterEstablishedForm", [])
             if later:
+                print(top['id'])
                 if type(later) != list:
                     later = [later]
                 for l in later:
@@ -268,7 +269,6 @@ class LcMapper(Mapper):
                     elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:
-                        print(reid)
                         earliers.append(reid)
                 ex.extend(earliers)
 

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -233,7 +233,6 @@ class LcMapper(Mapper):
             if later:
                 if type(later) != list:
                     later = [later]
-                print(later)
                 for l in later:
                     if "madsrdf:variantLabel" in l:
                         if "@value" in l["madsrdf:variantLabel"]:
@@ -247,11 +246,12 @@ class LcMapper(Mapper):
                     else:
                         lid = None
                     if lid.startswith("_:") and txt:
+                        print(lid)
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
                         rlid = None
                     else:
-                        rlid = lid 
+                        rlid = lid
                     if rlid:
                         laters.append(rlid)
                 ex.extend(laters)

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -268,6 +268,7 @@ class LcMapper(Mapper):
                     elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:
+                        print(reid)
                         earliers.append(reid)
                 ex.extend(earliers)
 

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -258,6 +258,7 @@ class LcMapper(Mapper):
                         reid = eid 
                     if reid:
                         earliers.append(reid)
+                        print(f"Earlier form reconciled for {new["@id"]}")
                 ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -57,6 +57,11 @@ class LcMapper(Mapper):
         elif rectype == "Person":
             rec["type"] == "Person"
             reconrec = nafreconciler.reconcile(rec, reconcileType="name")
+        elif rectype == "Type":
+            rec["type"] = "Type"
+            reconrec = shreconciler.reconcile(rec, reconcileType="name")
+        else:
+            reconrec = None
 
         return reconrec
 
@@ -236,7 +241,7 @@ class LcMapper(Mapper):
                     if "@id" in l:
                         lid = l['@id']
                     if txt and (not lid or lid.startswith("_:")):
-                        rlid = self.build_recs_and_reconcile(txt, str(type(top).__name__))
+                        rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
                         rlid = None 
                     if rlid:
@@ -258,10 +263,8 @@ class LcMapper(Mapper):
                             txt = None
                     if "@id" in e:
                         eid = e['@id']
-                    print(str(type(top).__name__))
-                    print(type(type(top).__name__))
                     if txt and (not eid or eid.startswith("_:")):
-                        reid = self.build_recs_and_reconcile(txt, str(type(top).__name__))
+                        reid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):
                         reid = None 
                     if reid:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -258,6 +258,7 @@ class LcMapper(Mapper):
                             txt = None 
                     if "@id" in e:
                         eid = e['@id']
+                    print(eid)
                     if txt and (not eid or eid.startswith("_:")):
                         eid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -31,6 +31,30 @@ class LcMapper(Mapper):
 
         self.ignore_types = ["madsrdf:DeprecatedAuthority", "madsrdf:NameTitle"]
 
+    def build_recs_and_reconcile(self, txt, rectype=""):
+        # reconrec returns URI
+        rec = {
+            "type": "",
+            "identified_by": [
+                {
+                    "type": "Name",
+                    "content": txt,
+                    "classified_as": [{"id": "http://vocab.getty.edu/aat/300404670"}],
+                }
+            ],
+        }
+        if rectype == "place":
+            rec["type"] = "Place"
+            reconrec = self.config["reconciler"].reconcile(rec, reconcileType="name")
+        elif rectype == "concept":
+            rec["type"] = "Type"
+            reconrec = self.config["all_configs"].external["lcsh"]["reconciler"].reconcile(rec, reconcileType="name")
+        elif rectype == "group":
+            rec["type"] = "Group"
+            reconrec = self.config["reconciler"].reconcile(rec, reconcileType="name")
+
+        return reconrec
+
     def fix_identifier(self, identifier):
         if identifier == "@@LMI-SPECIAL-TERM@@":
             return None
@@ -193,11 +217,13 @@ class LcMapper(Mapper):
             if later:
                 if type(later) != list:
                     later = [later]
+                print(later)
                 ex.extend(later)
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]
+                print(earlier)
                 ex.extend(earlier)
 
         # skos:closeMatch -- Only as a last resort
@@ -403,30 +429,6 @@ class LcnafMapper(LcMapper):
         else:
             self.parenthetical_places = {}
 
-    def build_recs_and_reconcile(self, txt, rectype=""):
-        # reconrec returns URI
-
-        rec = {
-            "type": "",
-            "identified_by": [
-                {
-                    "type": "Name",
-                    "content": txt,
-                    "classified_as": [{"id": "http://vocab.getty.edu/aat/300404670"}],
-                }
-            ],
-        }
-        if rectype == "place":
-            rec["type"] = "Place"
-            reconrec = self.config["reconciler"].reconcile(rec, reconcileType="name")
-        elif rectype == "concept":
-            rec["type"] = "Type"
-            reconrec = self.config["all_configs"].external["lcsh"]["reconciler"].reconcile(rec, reconcileType="name")
-        elif rectype == "group":
-            rec["type"] = "Group"
-            reconrec = self.config["reconciler"].reconcile(rec, reconcileType="name")
-
-        return reconrec
 
     def transform(self, record, rectype=None, reference=False):
         try:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -255,10 +255,10 @@ class LcMapper(Mapper):
                             if "(" in txt:
                                 txt = re.sub(r"^\(.*?\)\s*", "", txt)
                         else:
-                            txt = None 
+                            txt = None
+                    print(txt) 
                     if "@id" in e:
                         eid = e['@id']
-                    print(eid)
                     if txt and (not eid or eid.startswith("_:")):
                         eid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -258,6 +258,8 @@ class LcMapper(Mapper):
                             txt = None
                     if "@id" in e:
                         eid = e['@id']
+                    print(str(type(top).__name__))
+                    print(type(type(top).__name__))
                     if txt and (not eid or eid.startswith("_:")):
                         reid = self.build_recs_and_reconcile(txt, str(type(top).__name__))
                     elif not txt and eid.startswith("_:"):

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -246,7 +246,6 @@ class LcMapper(Mapper):
                     else:
                         lid = None
                     if lid.startswith("_:") and txt:
-                        print(lid)
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
                         rlid = None
@@ -259,6 +258,7 @@ class LcMapper(Mapper):
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             earliers = []
             if earlier:
+                print(earlier)
                 if type(earlier) != list:
                     earlier = [earlier]
                 for e in earlier:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -266,6 +266,7 @@ class LcMapper(Mapper):
                             txt = e['madsrdf:variantLabel']
                     else:
                         txt = None
+                    print(txt)
                     if "@id" in e:
                         eid = e['@id']
                     else:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -246,7 +246,6 @@ class LcMapper(Mapper):
                     else:
                         lid = None
                     if lid.startswith("_:") and txt:
-                        print(txt)
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
                         rlid = None
@@ -259,6 +258,7 @@ class LcMapper(Mapper):
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             earliers = []
             if earlier:
+                print(earlier)
                 if type(earlier) != list:
                     earlier = [earlier]
                 for e in earlier:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -271,7 +271,8 @@ class LcMapper(Mapper):
                         eid = None
                     if eid.startswith("_:") and txt:
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                        print(reid)
+                        print(type(top).__name__)
+                        print(type(type(top).__name__))
                     elif not txt and eid.startswith("_:"):
                         reid = None
                     else:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -60,6 +60,9 @@ class LcMapper(Mapper):
         elif rectype == "Type":
             rec["type"] = "Type"
             reconrec = shreconciler.reconcile(rec, reconcileType="name")
+        elif rectype == "Activity":
+            rec["type"] = "Activity"
+            reconrec = nafreconciler.reconcile(rec, reconcileType="name")
         else:
             reconrec = None
 
@@ -271,8 +274,7 @@ class LcMapper(Mapper):
                         eid = None
                     if eid.startswith("_:") and txt:
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                        print(type(top).__name__)
-                        print(type(type(top).__name__))
+                        print(reid)
                     elif not txt and eid.startswith("_:"):
                         reid = None
                     else:

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -242,10 +242,12 @@ class LcMapper(Mapper):
                         lid = l['@id']
                     else:
                         lid = None
-                    if txt and (not lid or lid.startswith("_:")):
+                    if lid.startswith("_:") and txt:
                         rlid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and lid.startswith("_:"):
-                        rlid = None 
+                        rlid = None
+                    else:
+                        rlid = lid 
                     if rlid:
                         laters.append(rlid)
                 ex.extend(laters)
@@ -267,10 +269,12 @@ class LcMapper(Mapper):
                         eid = e['@id']
                     else:
                         eid = None
-                    if txt and (not eid or eid.startswith("_:")):
+                    if eid.startswith("_:") and txt:
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
                     elif not txt and eid.startswith("_:"):
-                        reid = None 
+                        reid = None
+                    else:
+                        reid = eid 
                     if reid:
                         earliers.append(reid)
                 ex.extend(earliers)

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -260,6 +260,7 @@ class LcMapper(Mapper):
             if earlier:
                 if type(earlier) != list:
                     earlier = [earlier]
+                print(earlier)
                 for e in earlier:
                     if "madsrdf:variantLabel" in e:
                         if "@value" in e["madsrdf:variantLabel"]:
@@ -274,7 +275,6 @@ class LcMapper(Mapper):
                         eid = None
                     if eid.startswith("_:") and txt:
                         reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                        print(reid)
                     elif not txt and eid.startswith("_:"):
                         reid = None
                     else:


### PR DESCRIPTION
this was not as useful as an idea as I imagined it would be.

it doesn't apply to later established forms (those are all id.loc uris)
and earlier ones...either don't exist as records in LC anymore (they just end up as variant names), or we don't seem to use them in LUX, because all the ones I checked were not in the LC indexes/name reconciliation failed.

so I have no example to prove this does what I intend, but I ran it through LCSH and LCNAF datacaches without failure. 

I did move the function into the LcMapper Class to make it available in both sub-Classes, which might be useful at some point, and if any of the earliers can one day reconcile via this method, it should do so. It also removes any blank nodes from ending up in the equivalent list.

