### PR TITLE
allow 3.0 version licenses

### DIFF
--- a/pipeline/sources/general/wikimedia/mapper.py
+++ b/pipeline/sources/general/wikimedia/mapper.py
@@ -8,7 +8,7 @@ class WmMapper(Mapper):
 
     def __init__(self, config):
         Mapper.__init__(self, config)
-        self.licenses = config.get('allowed_licenses', ['pd', 'cc0', 'cc-by-sa-4.0', 'cc-by-4.0'])
+        self.licenses = config.get('allowed_licenses', ['pd', 'cc0', 'cc-by-sa-4.0', 'cc-by-4.0', 'cc-by-sa-3.0', 'cc-by-3.0'])
 
     def transform(self, record, rectype, reference=False):
 


### PR DESCRIPTION
example: we have no image for the Rijks, because the license on the WM image is old (3.0). propose to allow 3.0 versions of the 4.0 license.

https://lux.collections.yale.edu/view/group/37870dee-ea1f-48e5-b83a-1f7bda5331d2