### PR TITLE
Lc mpr fix redux

### DIFF
--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -13,6 +13,8 @@ class Reconciler(object):
         self.debug_graph = {}
 
     def should_reconcile(self, rec, reconcileType="all"):
+        print(f"Debug: rec={rec}, reconcileType={reconcileType}")
+        print(f"Debug: data={data}") 
         if "data" in rec:
             data = rec["data"]
         if self.name_index is None and reconcileType == "name":

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -34,7 +34,7 @@ class Reconciler(object):
                 return False
             if "equivalent" not in data:
                 return False
-        elif reconcileType == "all" and seld.name_index is None and self.id_index is None:
+        elif reconcileType == "all" and self.name_index is None and self.id_index is None:
             return False
 
         if rec.get("source") and rec["source"] == self.config["name"]:
@@ -183,8 +183,6 @@ class LmdbReconciler(Reconciler):
         if not reconcileType in ["all", "name", "uri"]:
             return None
         if not self.should_reconcile(rec, reconcileType):
-            print(f"rec at line 178 is {rec}")
-            print(f"reconcileType at line 179 is {reconcileType}")
             return None
         if "data" in rec:
             rec = rec["data"]

--- a/pipeline/process/base/reconciler.py
+++ b/pipeline/process/base/reconciler.py
@@ -13,26 +13,34 @@ class Reconciler(object):
         self.debug_graph = {}
 
     def should_reconcile(self, rec, reconcileType="all"):
-        print(f"Debug: rec={rec}, reconcileType={reconcileType}")
-        print(f"Debug: data={data}") 
-        if "data" in rec:
-            data = rec["data"]
-        if self.name_index is None and reconcileType == "name":
+        """
+        Determines whether a record should be reconciled based on the type of reconciliation.
+
+        Args:
+            rec (dict): The record to evaluate for reconciliation.
+            reconcileType (str): The type of reconciliation ("name", "uri", or "all").
+
+        Returns:
+            bool: True if the record should be reconciled, False otherwise.
+        """
+        data = rec.get("data",rec)
+        if reconcileType == "name":
+            if self.name_index is None:
+                return False
+            if "identified_by" not in data:
+                return False  # Records without names should not be reconciled
+        elif reconcileType == "uri":
+            if self.id_index is None:
+                return False
+            if "equivalent" not in data:
+                return False
+        elif reconcileType == "all" and seld.name_index is None and self.id_index is None:
             return False
-        elif self.id_index is None and reconcileType == "uri":
-            return False
-        elif "identified_by" not in data and reconcileType == "name":
-            # record without a name should never happen ... but ...
-            return False
-        elif "equivalent" not in data and reconcileType == "uri":
-            return False
-        elif "source" in rec and rec["source"] == self.config["name"]:
+
+        if rec.get("source") and rec["source"] == self.config["name"]:
             # Don't reconcile against self
             return False
-        elif (
-            self.name_index is None and self.id_index is None and reconcileType == "all"
-        ):
-            return False
+
         return True
 
     def reconcile(self, record, reconcileType="all"):
@@ -175,6 +183,8 @@ class LmdbReconciler(Reconciler):
         if not reconcileType in ["all", "name", "uri"]:
             return None
         if not self.should_reconcile(rec, reconcileType):
+            print(f"rec at line 178 is {rec}")
+            print(f"reconcileType at line 179 is {reconcileType}")
             return None
         if "data" in rec:
             rec = rec["data"]

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -236,29 +236,22 @@ class LcMapper(Mapper):
             earlier = new.get("madsrdf:hasEarlierEstablishedForm", [])
             earliers = []
             if earlier:
-                if type(earlier) != list:
+                if not isinstance(earlier, list):
                     earlier = [earlier]
+
                 for e in earlier:
-                    if "madsrdf:variantLabel" in e:
-                        if "@value" in e["madsrdf:variantLabel"]:
-                            txt = e['madsrdf:variantLabel']['@value']
-                        else:
-                            txt = e['madsrdf:variantLabel']
+                    txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
+                    eid = e.get("@id")
+
+                    reid = None 
+                    if eid and eid.startswith("_:"):
+                        if txt:
+                            reid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                            print(f"Earlier form reconciled for {new['@id']}")
                     else:
-                        txt = None
-                    if "@id" in e:
-                        eid = e['@id']
-                    else:
-                        eid = None
-                    if eid.startswith("_:") and txt:
-                        reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                    elif not txt and eid.startswith("_:"):
-                        reid = None
-                    else:
-                        reid = eid 
+                        reid = eid
                     if reid:
                         earliers.append(reid)
-                        print(f"Earlier form reconciled for {new['@id']}")
                 ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -238,22 +238,21 @@ class LcMapper(Mapper):
             if earlier:
                 if not isinstance(earlier, list):
                     earlier = [earlier]
-                    print(f"Earlier is {earlier}")
                 for e in earlier:
                     print(f"----Type of E is {type(e)}\n")
-                #     txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
-                #     eid = e.get("@id")
+                    txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
+                    eid = e.get("@id")
 
-                #     reid = None 
-                #     if eid and eid.startswith("_:"):
-                #         if txt:
-                #             reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                #             print(f"Earlier form reconciled for {new['@id']}")
-                #     else:
-                #         reid = eid
-                #     if reid:
-                #         earliers.append(reid)
-                # ex.extend(earliers)
+                    reid = None 
+                    if eid and eid.startswith("_:"):
+                        if txt:
+                            reid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                            print(f"Earlier form reconciled for {new['@id']}")
+                    else:
+                        reid = eid
+                    if reid:
+                        earliers.append(reid)
+                ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort
         close = new.get("madsrdf:hasCloseExternalAuthority", [])

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -239,8 +239,8 @@ class LcMapper(Mapper):
                 if not isinstance(earlier, list):
                     earlier = [earlier]
                 for e in earlier:
-                    print(f"----Type of E is {type(e)}\n")
-                    txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
+                    txt = e.get("madsrdf:variantLabel")
+                    txt = txt.get("@value") if isinstance(txt, dict) else txt
                     eid = e.get("@id")
 
                     reid = None 

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -238,21 +238,22 @@ class LcMapper(Mapper):
             if earlier:
                 if not isinstance(earlier, list):
                     earlier = [earlier]
-
+                    print(f"Earlier is {earlier}")
                 for e in earlier:
-                    txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
-                    eid = e.get("@id")
+                    print(f"E is {e}")
+                #     txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
+                #     eid = e.get("@id")
 
-                    reid = None 
-                    if eid and eid.startswith("_:"):
-                        if txt:
-                            reid = self.build_recs_and_reconcile(txt, type(top).__name__)
-                            print(f"Earlier form reconciled for {new['@id']}")
-                    else:
-                        reid = eid
-                    if reid:
-                        earliers.append(reid)
-                ex.extend(earliers)
+                #     reid = None 
+                #     if eid and eid.startswith("_:"):
+                #         if txt:
+                #             reid = self.build_recs_and_reconcile(txt, type(top).__name__)
+                #             print(f"Earlier form reconciled for {new['@id']}")
+                #     else:
+                #         reid = eid
+                #     if reid:
+                #         earliers.append(reid)
+                # ex.extend(earliers)
 
         # skos:closeMatch -- Only as a last resort
         close = new.get("madsrdf:hasCloseExternalAuthority", [])

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -55,7 +55,7 @@ class LcMapper(Mapper):
             rec["type"] = "Group"
             reconrec = nafreconciler.reconcile(rec, reconcileType="name")
         elif rectype == "Person":
-            rec["type"] == "Person"
+            rec["type"] = "Person"
             reconrec = nafreconciler.reconcile(rec, reconcileType="name")
         elif rectype == "Type":
             rec["type"] = "Type"

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -240,7 +240,7 @@ class LcMapper(Mapper):
                     earlier = [earlier]
                     print(f"Earlier is {earlier}")
                 for e in earlier:
-                    print(f"----E is {e}\n")
+                    print(f"----Type of E is {type(e)}\n")
                 #     txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
                 #     eid = e.get("@id")
 

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -56,21 +56,26 @@ class LcMapper(Mapper):
                     "classified_as": [{"id": "http://vocab.getty.edu/aat/300404670"}],
                 }
             ],
+            "source": ""
         }
 
         # Map rectype to reconciler and record type
         reconcilers = {
-            "Place": (nafreconciler, "Place"),
-            "Concept": (shreconciler, "Type"),
-            "Group": (nafreconciler, "Group"),
-            "Person": (nafreconciler, "Person"),
-            "Type": (shreconciler, "Type"),
-            "Activity": (nafreconciler, "Activity"),
+            "Place": nafreconciler,
+            "Concept": shreconciler,
+            "Group": nafreconciler,
+            "Person": nafreconciler, 
+            "Type": shreconciler,
+            "Activity": nafreconciler
         }
 
         if rectype in reconcilers:
-            reconciler, rec_type = reconcilers[rectype]
-            rec["type"] = rec_type
+            reconciler = reconcilers[rectype]
+            rec["type"] = rectype
+            if rectype in ["Place","Group","Person","Ativity"]:
+                rec["source"] = "lcnaf"
+            else:
+                rec["source"] = "lcsh"
             reconrec = reconciler.reconcile(rec, reconcileType="name")
         else:
             # Handle invalid rectype

--- a/pipeline/sources/authorities/lc/mapper.py
+++ b/pipeline/sources/authorities/lc/mapper.py
@@ -240,7 +240,7 @@ class LcMapper(Mapper):
                     earlier = [earlier]
                     print(f"Earlier is {earlier}")
                 for e in earlier:
-                    print(f"E is {e}")
+                    print(f"----E is {e}\n")
                 #     txt = e.get("madsrdf:variantLabel", {}).get("@value", e.get("madsrdf:variantLabel"))
                 #     eid = e.get("@id")
 


### PR DESCRIPTION
There were some bugs related to the Oct 16 change to the LC Mapper (refactoring the build_recs_and_reconcile function and the addition of reconciling earlier established forms) and the dependencies in the should_reconcile function in the base reconciler that were breaking LC mapper and failing in reconciliation.

Run-reconcile now reconciles this 
[37dd871d-e5cd-45d7-b0bd-c0a19a4207c9](https://linked-art.library.yale.edu/node/37dd871d-e5cd-45d7-b0bd-c0a19a4207c9) library record correctly and doesn't create a separate one.

Not sure this is 100% of our recent struggles but definitely an issue.