### PR TITLE
process Sets for PCSH

### DIFF
--- a/pipeline/sources/yale/library/mapper.py
+++ b/pipeline/sources/yale/library/mapper.py
@@ -127,7 +127,7 @@ class YulMapper(Mapper):
             return None
 
         # replace compound subject headings with their components on LinguisticObjects
-        if data["type"] == "LinguisticObject":
+        if data["type"] in ["LinguisticObject","Set"]:
             current_about = data.get("about", [])
             new_about = []
             for a in current_about:


### PR DESCRIPTION
Original PR missed accounting for Sets :(

One line change. The YCBA objects/exhibitions code can stay where it is, it just won't find anything for Sets in that block.