### PR TITLE
allow empty ids in dedupe function

### DIFF
--- a/pipeline/sources/lux/final/mapper.py
+++ b/pipeline/sources/lux/final/mapper.py
@@ -452,9 +452,14 @@ class Cleaner(Mapper):
         replacement = []
         for c in data.get(prop, []):
             c_id = c.get("id", "")
-            if c_id and c_id not in counter:
-                counter[c_id] = 1
+            if c_id:
+                if c_id not in counter:
+                    counter[c_id] = 1
+                    replacement.append(c)
+            else:
+                #allow for empty ids
                 replacement.append(c)
+
         if replacement:
             data[prop] = replacement
 


### PR DESCRIPTION
this is why classified_as PCSH failed. 

good example for testing: https://linked-art.library.yale.edu/node/20414a39-654a-48bd-9cc8-47245505719b