### PR TITLE
upstream check for values

### DIFF
--- a/pipeline/sources/general/wikimedia/fetcher.py
+++ b/pipeline/sources/general/wikimedia/fetcher.py
@@ -12,3 +12,16 @@ class WmFetcher(Fetcher):
         if '#' in identifier:
             identifier = identifier.split('#', 1)[0]
         return self.fetch_uri.format(identifier=identifier)
+
+    def post_process(self, data, identifier):
+        try:
+            pages = data.get('query', {}).get('pages', {})
+            if not pages:
+                return None
+            page = next(iter(pages.values()))
+            if 'imageinfo' not in page or not page['imageinfo']:
+                return None
+        except Exception as e:
+            return None
+
+        return data


### PR DESCRIPTION
this is my best guess on how to fix https://www.bugherd.com/projects/284041/tasks/2964.

the actual file isn't wikiartis, it's a very normal looking `https://commons.wikimedia.org/wiki/Special:Filepath/Jenny holzer.jpg`, but the API response doesn't have the necessary keys and mapper returns None on it. 

However it's still being cached and ending up in the LUX record, not sure why when the Mapper returns None. I think maybe it needs caught upstream via post_process in the Fetcher hence this PR. I'm also going to run a cleanup script on our Wikimedia cache to delete items without the necessary data. I'll log them.