### PR TITLE
Replace OOM version with streaming fix

### DIFF
--- a/convert_assertions.py
+++ b/convert_assertions.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Convert legacy assertion logs to the new AssertionWriter format.
+
+The old reconcile phase wrote two-column, full-URI lines::
+
+    <asserter/subject qua-uri>\t<equivalent qua-uri>
+
+(the asserter was implicitly the first column, and a record with no
+equivalents wrote ``uri\turi``).
+
+The new AssertionWriter (pipeline/process/identity.py) writes three columns
+of *shortened* (curie) URIs in canonical order::
+
+    <lesser-uri>\t<greater-uri>\t<asserter-uri>
+
+so the files can be sorted and streamed without loading them into memory.
+
+This utility rewrites an existing directory of legacy files into the new
+format, using the same namespace map the idmap/AssertionWriter use. It is a
+one-time migration for assertion logs produced before the format change;
+new runs of run-reconcile.py already emit the new format directly.
+
+Usage:
+    python convert_assertions.py INPUT_DIR OUTPUT_DIR
+
+The namespace map comes from the real pipeline Config when it can be loaded
+(so the short forms match redis exactly); otherwise a self-contained
+fallback map covering the LUX source namespaces is used (fine for testing /
+standalone conversion, where nothing needs to line up with a live idmap).
+"""
+
+import glob
+import os
+import sys
+import time
+
+from pipeline.process.identity import build_prefix_maps, expand, shorten
+
+
+# ---------------------------------------------------------------------------
+# namespace map
+# ---------------------------------------------------------------------------
+
+class _FallbackConfig:
+    """Enough of Config for build_prefix_maps() when the real config_cache
+    is not available. Covers the LUX internal data sources and external
+    authorities. Short names are collision-free (no name is a prefix of
+    another) so expand() round-trips."""
+
+    internal_uri = "https://lux.collections.yale.edu/data/"
+
+    # name -> namespace prefix. Order does not matter for shorten() because
+    # no namespace is a prefix of another distinct namespace.
+    _NS = [
+        # LUX data sources
+        ("lald", "https://linked-art.library.yale.edu/"),
+        ("ypm", "https://images.peabody.yale.edu/"),
+        ("yuag", "https://media.art.yale.edu/"),
+        ("ycba", "https://ycba-lux.s3.amazonaws.com/v3/"),
+        ("pmc", "https://data.paul-mellon-centre.ac.uk/"),
+        ("pb", "https://paperbase.xyz/"),
+        ("exm", "http://lod.example.org/museum/"),
+        # external authorities
+        ("aat", "http://vocab.getty.edu/aat/"),
+        ("ulan", "http://vocab.getty.edu/ulan/"),
+        ("tgn", "http://vocab.getty.edu/tgn/"),
+        ("wikidata", "http://www.wikidata.org/entity/"),
+        ("wikimedia", "http://commons.wikimedia.org/"),
+        ("viaf", "http://viaf.org/viaf/"),
+        ("geonames", "https://sws.geonames.org/"),
+        ("wof", "http://data.whosonfirst.org/"),
+        ("dnb", "https://d-nb.info/gnd/"),
+        ("bnf", "https://data.bnf.fr/ark:/12148/"),
+        ("bne", "https://datos.bne.es/resource/"),
+        ("gbif", "https://www.gbif.org/species/"),
+        ("lcnaf", "http://id.loc.gov/authorities/names/"),
+        ("lcsh", "http://id.loc.gov/authorities/subjects/"),
+        ("lcdgt", "http://id.loc.gov/authorities/demographicTerms/"),
+        ("ror", "https://ror.org/"),
+    ]
+
+    def __init__(self):
+        self.external = {name: {"name": name, "namespace": ns}
+                         for name, ns in self._NS}
+
+
+def load_prefix_maps():
+    """(prefix_in, prefix_out, source-label). Prefer the real Config so the
+    short forms match the live idmap; fall back to the built-in LUX map."""
+    try:
+        from pipeline.config import Config
+        cfgs = Config(basepath=os.getenv("LUX_BASEPATH", ""))
+        pin, pout = build_prefix_maps(cfgs)
+        return pin, pout, "pipeline.config.Config"
+    except Exception as e:
+        pin, pout = build_prefix_maps(_FallbackConfig())
+        return pin, pout, f"fallback map ({type(e).__name__} loading Config)"
+
+
+# ---------------------------------------------------------------------------
+# conversion
+# ---------------------------------------------------------------------------
+
+def convert_file(src, dst, prefix_in):
+    """Stream one legacy file into the new format. Returns (lines, self)."""
+    lines = 0
+    selfs = 0
+    with open(src) as fin, open(dst, "w") as fout:
+        for line in fin:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) == 3:
+                # already new format: pass through unchanged
+                fout.write(line if line.endswith("\n") else line + "\n")
+                lines += 1
+                continue
+            if len(parts) != 2:
+                continue
+            a, b = parts
+            asserter = shorten(a, prefix_in)
+            sa = asserter
+            sb = shorten(b, prefix_in)
+            lo, hi = (sa, sb) if sa <= sb else (sb, sa)
+            fout.write(f"{lo}\t{hi}\t{asserter}\n")
+            lines += 1
+            if a == b:
+                selfs += 1
+    return lines, selfs
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(2)
+    in_dir, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+
+    prefix_in, prefix_out, source = load_prefix_maps()
+    print(f"namespace map: {source} ({len(prefix_out)} prefixes)")
+
+    files = sorted(glob.glob(os.path.join(in_dir, "assertions-*.tsv")))
+    if not files:
+        print(f"No assertions-*.tsv in {in_dir}")
+        sys.exit(1)
+
+    total_lines = total_self = 0
+    in_bytes = out_bytes = 0
+    t0 = time.time()
+    for src in files:
+        dst = os.path.join(out_dir, os.path.basename(src))
+        lines, selfs = convert_file(src, dst, prefix_in)
+        total_lines += lines
+        total_self += selfs
+        in_bytes += os.path.getsize(src)
+        out_bytes += os.path.getsize(dst)
+        print(f"  {os.path.basename(src):24s} {lines:>10,} lines "
+              f"({selfs:,} self)")
+    dt = time.time() - t0
+
+    print(f"\n{len(files)} files, {total_lines:,} lines "
+          f"({total_self:,} self-assertions) in {dt:.0f}s")
+    print(f"size: {in_bytes/1e9:.2f} GB -> {out_bytes/1e9:.2f} GB "
+          f"({100 * out_bytes / in_bytes:.0f}% of original)")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/process/identity.py
+++ b/pipeline/process/identity.py
@@ -5,9 +5,13 @@ manage_identifiers) with a three step flow whose output is a pure function
 of the input assertions, independent of worker count and scheduling:
 
 1. During reconciliation each worker slice logs sameAs *assertions*
-   (asserter, subject, object) to an append-only file via AssertionWriter.
-   No idmap writes happen during reconciliation.
-2. After all slices finish, run-identify.py aggregates the assertion files
+   (subject, object, asserter) to an append-only file via AssertionWriter.
+   URIs are shortened to the same curie form the idmap stores internally
+   (``aat:300010001##quaType``) and each line is written in canonical order
+   -- lesser URI, greater URI, then the asserting record -- so the file can
+   be sorted and streamed without loading it into memory. No idmap writes
+   happen during reconciliation.
+2. After all slices finish, run-identify.py resolves the assertion files
    into voted pair-edges and clusters them with a constrained union-find:
    edges are processed most-voted-first (lexicographic tie-break) and a
    union is refused when any differentFrom pair spans the two clusters --
@@ -21,28 +25,97 @@ of the input assertions, independent of worker count and scheduling:
    YUID mint uuid5(min member). The resulting map is bulk-loaded into the
    redis idmap in pipelined batches for the merge phase to use as before.
 
-Validated against all 505k production concept clusters in
-experiments/recon_test (byte-identical output across schedules, 100% YUID
-reproduction on rebuild, YUIDs stable under new-URI perturbation, and
-correct voted resolution of injected wrong links / splits / vanished
-members / URI variants).
+At production scale (~45M records, tens of millions of URIs) the whole flow
+is executed by ``resolve_identity`` as a sequence of unix ``sort`` passes
+over temporary files with streaming Python in between, so peak memory
+scales with the *non-singleton* subgraph (URIs that share a cluster with at
+least one other URI) rather than with the total record count. The bulk of
+records are singletons -- a URI with no equivalents -- and never enter the
+in-memory union-find at all.
+
+The pure in-memory helpers (load_assertions, cluster, assign,
+apply_assignments, ...) remain the reference implementation: they encode
+the exact semantics the streaming path reproduces and back the unit tests /
+legacy comparison harness.
 """
 
+import os
+import shutil
+import subprocess
+import tempfile
 import uuid
 from collections import defaultdict
 
 import ujson as json
 
 
+# ---------------------------------------------------------------------------
+# URI shortening (mirrors IdMap._manage_key_in / _manage_key_out exactly)
+# ---------------------------------------------------------------------------
+
+def build_prefix_maps(configs):
+    """Reproduce the idmap's namespace<->curie maps from configs alone.
+
+    Matches ``IdMap.__init__``: ``prefix_out`` maps a short name to its full
+    namespace (yuid first, then each external source in config order),
+    ``prefix_in`` is its inverse. Building from the same source in the same
+    order guarantees the on-disk short forms are byte-identical to what redis
+    stores internally, which is what lets the srem/sadd round-trip in
+    apply_assignments match without any conversion.
+    """
+    prefix_out = {"yuid": configs.internal_uri}
+    for cf in configs.external.values():
+        prefix_out[cf["name"]] = cf["namespace"]
+    prefix_in = {}
+    for k, v in prefix_out.items():
+        prefix_in[v] = k
+    return prefix_in, prefix_out
+
+
+def shorten(uri, prefix_in):
+    """Full URI -> curie (``http://vocab.getty.edu/aat/1##quaType`` ->
+    ``aat:1##quaType``). Byte-for-byte identical to
+    RedisCache._manage_key_in: only ``http`` URIs are touched, first
+    namespace match (in insertion order) wins, and the ``##qua`` suffix is
+    left untouched so is_qua/split_qua still work on the short form. URIs
+    with no matching namespace pass through unchanged."""
+    if uri.startswith("http"):
+        for k, v in prefix_in.items():
+            if uri.startswith(k):
+                return uri.replace(k, f"{v}:")
+    return uri
+
+
+def expand(uri, prefix_out):
+    """Curie -> full URI. Byte-for-byte identical to
+    RedisCache._manage_key_out (== IdMap._manage_value_out): only non-``http``
+    strings are touched, first short-name match wins. Inverse of shorten for
+    every URI a namespace matched."""
+    if not uri.startswith("http"):
+        for k, v in prefix_out.items():
+            if uri.startswith(k):
+                return uri.replace(f"{k}:", v)
+    return uri
+
+
+# ---------------------------------------------------------------------------
+# Assertion log
+# ---------------------------------------------------------------------------
+
 class AssertionWriter:
     """Per-slice append-only log of sameAs assertions.
 
     Files are written to the working directory alongside metatypes-*.json
-    and reference_uris.txt, named assertions-{slice}.tsv.
+    and reference_uris.txt, named assertions-{slice}.tsv. Each line is
+    ``lo<TAB>hi<TAB>asserter`` where (lo, hi) are the two URIs of the
+    assertion in sorted order and asserter is the record that made it (one
+    of the two, in short form). A record with no equivalents logs a
+    self-assertion (``s  s  s``) so it still receives a YUID.
     """
 
     def __init__(self, configs, my_slice=-1):
         self.configs = configs
+        self.prefix_in, _ = build_prefix_maps(configs)
         if my_slice > -1:
             fn = f"assertions-{my_slice}.tsv"
         else:
@@ -58,17 +131,18 @@ class AssertionWriter:
             return
         recid = rec["data"]["id"]
         typ = rec["data"]["type"]
-        qrecid = self.configs.make_qua(recid, typ)
+        qrecid = shorten(self.configs.make_qua(recid, typ), self.prefix_in)
         wrote = False
         for eq in rec["data"].get("equivalent", []):
             eqid = eq.get("id")
             if not eqid or eqid == recid:
                 continue
-            qeq = self.configs.make_qua(eqid, typ)
-            self.fh.write(f"{qrecid}\t{qeq}\n")
+            qeq = shorten(self.configs.make_qua(eqid, typ), self.prefix_in)
+            lo, hi = (qrecid, qeq) if qrecid <= qeq else (qeq, qrecid)
+            self.fh.write(f"{lo}\t{hi}\t{qrecid}\n")
             wrote = True
         if not wrote:
-            self.fh.write(f"{qrecid}\t{qrecid}\n")
+            self.fh.write(f"{qrecid}\t{qrecid}\t{qrecid}\n")
 
     def close(self):
         self.fh.close()
@@ -77,31 +151,41 @@ class AssertionWriter:
 def load_assertions(files):
     """Aggregate assertion files into pair -> set(asserters).
 
-    Canonical pair = sorted URI strings, so the result is independent of
-    file order, line order, and which slice emitted which assertion.
+    In-memory reference implementation. Canonical pair = sorted URI strings,
+    so the result is independent of file order, line order, and which slice
+    emitted which assertion. The streaming path in resolve_identity produces
+    the same voted edges without holding this dict in memory.
     """
     edges = defaultdict(set)
     for fn in sorted(str(f) for f in files):
         with open(fn) as fh:
             for line in fh:
-                try:
-                    a, b = line.rstrip("\n").split("\t")
-                except ValueError:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) == 3:
+                    a, b, asserter = parts
+                elif len(parts) == 2:
+                    # legacy 2-column form: asserter was the first column
+                    a, b = parts
+                    asserter = a
+                else:
                     continue
-                asserter = a
                 if a > b:
                     a, b = b, a
                 edges[(a, b)].add(asserter)
     return edges
 
 
-def load_diff_pairs(diff_index, nodes):
+def load_diff_pairs(diff_index, nodes, prefix_in=None):
     """differentFrom pairs from the merged differents index (TabLmdb of
     URI -> URI(s)), lifted onto the qua'd node forms present in the graph.
 
     The raw table has no types; a diff between two URIs constrains every
     qua'd form of those URIs, matching how the GlobalReconciler applies
     diffs against equivalent ids irrespective of type.
+
+    ``nodes`` are curie-shortened when the graph is (pass ``prefix_in`` so
+    the full-URI diff keys are shortened to match); otherwise both sides are
+    full URIs and prefix_in is left None.
     """
     by_uri = defaultdict(list)
     for n in nodes:
@@ -110,18 +194,32 @@ def load_diff_pairs(diff_index, nodes):
     diffs = set()
     if diff_index is None:
         return diffs
+
+    def key_of(uri):
+        if prefix_in is not None:
+            uri = shorten(uri, prefix_in)
+        return uri.split("##qua")[0]
+
     for k in diff_index.keys():
         vals = diff_index[k]
         if isinstance(vals, str):
             vals = [vals]
+        ks = key_of(k)
+        srcs = by_uri.get(ks)
+        if not srcs:
+            continue
         for v in vals:
-            for qa in by_uri.get(k, ()):
-                for qb in by_uri.get(v, ()):
+            for qa in srcs:
+                for qb in by_uri.get(key_of(v), ()):
                     if qa == qb:
                         continue
                     diffs.add((qa, qb) if qa < qb else (qb, qa))
     return diffs
 
+
+# ---------------------------------------------------------------------------
+# Union-find
+# ---------------------------------------------------------------------------
 
 class DSU:
     def __init__(self):
@@ -154,8 +252,50 @@ class DSU:
         return rx
 
 
+def _constrained_union(dsu, edge_stream, diffs, want_conflicts=True):
+    """Run the constrained union-find, consuming ``edge_stream`` -- an
+    iterable of ``(a, b, votes)`` already ordered most-voted-first, then by
+    pair -- against the ``diffs`` enemy set. Shared by the in-memory
+    ``cluster`` and the streaming path so both refuse the same links.
+
+    Returns a list of conflict dicts (without asserters filled in, since the
+    streaming caller attaches those from disk). ``dsu`` must already contain
+    every node that can be unioned.
+    """
+    enemies = defaultdict(set)
+    for (a, b) in diffs:
+        ra, rb = dsu.find(a), dsu.find(b)
+        if ra != rb:
+            enemies[ra].add(rb)
+            enemies[rb].add(ra)
+
+    conflicts = []
+    for a, b, votes in edge_stream:
+        if a == b:
+            continue
+        ra, rb = dsu.find(a), dsu.find(b)
+        if ra == rb:
+            continue
+        if rb in enemies[ra]:
+            if want_conflicts:
+                conflicts.append({
+                    "pair": [a, b],
+                    "votes": votes,
+                    "cluster_sizes": [dsu.size[ra], dsu.size[rb]],
+                })
+            continue
+        merged = dsu.union(a, b)
+        loser = rb if merged == ra else ra
+        if enemies[loser]:
+            for e in enemies.pop(loser):
+                enemies[e].discard(loser)
+                enemies[e].add(merged)
+                enemies[merged].add(e)
+    return conflicts
+
+
 def cluster(edges, diffs):
-    """Constrained union-find over voted edges.
+    """Constrained union-find over voted edges (in-memory reference).
 
     Returns (clusters keyed by min member, refused-assertion report).
     Processing order is fixed (votes desc, then pair) so the partition is
@@ -171,36 +311,17 @@ def cluster(edges, diffs):
         dsu.add(a)
         dsu.add(b)
 
-    enemies = defaultdict(set)
-    for (a, b) in diffs:
-        ra, rb = dsu.find(a), dsu.find(b)
-        if ra != rb:
-            enemies[ra].add(rb)
-            enemies[rb].add(ra)
-
     order = sorted(edges.items(), key=lambda kv: (-len(kv[1]), kv[0]))
-    conflicts = []
-    for (a, b), asserters in order:
-        if a == b:
-            continue
-        ra, rb = dsu.find(a), dsu.find(b)
-        if ra == rb:
-            continue
-        if rb in enemies[ra]:
-            conflicts.append({
-                "pair": [a, b],
-                "votes": len(asserters),
-                "asserters": sorted(asserters),
-                "cluster_sizes": [dsu.size[ra], dsu.size[rb]],
-            })
-            continue
-        merged = dsu.union(a, b)
-        loser = rb if merged == ra else ra
-        if enemies[loser]:
-            for e in enemies.pop(loser):
-                enemies[e].discard(loser)
-                enemies[e].add(merged)
-                enemies[merged].add(e)
+    stream = ((a, b, len(asserters)) for (a, b), asserters in order)
+    conflicts = _constrained_union(dsu, stream, diffs)
+    # attach asserters for the (rare) refused links
+    want = {(c["pair"][0], c["pair"][1]): c for c in conflicts}
+    for (a, b), asserters in edges.items():
+        c = want.get((a, b))
+        if c is not None:
+            c["asserters"] = sorted(asserters)
+    for c in conflicts:
+        c.setdefault("asserters", [])
 
     clusters = defaultdict(list)
     for node in dsu.parent:
@@ -212,6 +333,10 @@ def cluster(edges, diffs):
     conflicts.sort(key=lambda c: (c["pair"][0], c["pair"][1]))
     return out, conflicts
 
+
+# ---------------------------------------------------------------------------
+# YUID assignment
+# ---------------------------------------------------------------------------
 
 def mint_yuid(configs, cluster_key):
     """Deterministic mint for clusters with no prior YUID:
@@ -231,8 +356,24 @@ def mint_yuid(configs, cluster_key):
     return f"{base}{uu}"
 
 
+def _best_claim(prior_values):
+    """Given the prior YUIDs held by a cluster's members (Nones/blanks
+    allowed), return (best_yuid, votes) or None if no member had a prior.
+    Most votes wins; ties break to the lexicographically smallest YUID --
+    identical for the in-memory and streaming assignment paths."""
+    tally = defaultdict(int)
+    for y in prior_values:
+        if y:
+            tally[y] += 1
+    if not tally:
+        return None
+    top = max(tally.values())
+    best = min(y for y, n in tally.items() if n == top)
+    return best, tally[best]
+
+
 def assign(clusters, prior, configs):
-    """cluster (keyed by min member) -> YUID.
+    """cluster (keyed by min member) -> YUID (in-memory reference).
 
     Members vote for the YUID they held in the prior idmap; most voters
     wins (tie: lexicographically smallest YUID), so adding new URIs to a
@@ -242,15 +383,10 @@ def assign(clusters, prior, configs):
     """
     claims = defaultdict(list)
     for key, members in clusters.items():
-        tally = defaultdict(int)
-        for m in members:
-            y = prior.get(m)
-            if y:
-                tally[y] += 1
-        if tally:
-            top = max(tally.values())
-            best = min(y for y, n in tally.items() if n == top)
-            claims[best].append((tally[best], key))
+        claim = _best_claim(prior.get(m) for m in members)
+        if claim:
+            best, votes = claim
+            claims[best].append((votes, key))
 
     assigned = {}
     for yuid, claimants in claims.items():
@@ -274,7 +410,8 @@ BATCH = 5000
 
 
 def fetch_prior(idmap, members):
-    """Pipelined member -> YUID lookup from the current idmap."""
+    """Pipelined member -> YUID lookup from the current idmap (in-memory
+    reference; the streaming path fetches priors in batches on the fly)."""
     prior = {}
     members = list(members)
     conn = idmap.conn
@@ -290,7 +427,9 @@ def fetch_prior(idmap, members):
 
 
 def apply_assignments(idmap, clusters, yuids, prior):
-    """Bulk-load the resolved identity map into the redis idmap.
+    """Bulk-load the resolved identity map into the redis idmap (in-memory
+    reference used by the comparison harness; resolve_identity applies the
+    streaming equivalent).
 
     Keeps the same storage shape the merge phase expects: member -> yuid
     (string) and yuid -> set(members + current update token). Members that
@@ -323,11 +462,18 @@ def apply_assignments(idmap, clusters, yuids, prior):
             pipe.sadd(iyuid, *imembers, token)
         pipe.execute(raise_on_error=False)
 
-    # Remove yuid sets that lost all real members (merged/split away)
+    stats["deleted_yuids"] = _delete_dead_yuids(idmap, sorted(touched_old))
+    return stats
+
+
+def _delete_dead_yuids(idmap, iold_keys):
+    """Remove yuid sets that lost all real members (only update tokens left).
+    ``iold_keys`` is an iterable of already-internal (short) yuid keys."""
+    conn = idmap.conn
     dead = 0
-    touched_old = sorted(touched_old)
-    for i in range(0, len(touched_old), BATCH):
-        chunk = touched_old[i:i + BATCH]
+    iold_keys = list(iold_keys)
+    for i in range(0, len(iold_keys), BATCH):
+        chunk = iold_keys[i:i + BATCH]
         pipe = conn.pipeline(transaction=False)
         for iold in chunk:
             pipe.smembers(iold)
@@ -338,40 +484,362 @@ def apply_assignments(idmap, clusters, yuids, prior):
                 pipe.delete(iold)
                 dead += 1
         pipe.execute(raise_on_error=False)
-    stats["deleted_yuids"] = dead
+    return dead
+
+
+# ---------------------------------------------------------------------------
+# Streaming resolution (the production path)
+# ---------------------------------------------------------------------------
+
+def _sort(inputs, output, keys, tmpdir, buffer):
+    """Run ``LC_ALL=C sort`` (byte order == Python str order for UTF-8, so
+    the on-disk order matches every in-memory min/max the code does)."""
+    cmd = ["sort", *keys, "-t", "\t", "-T", tmpdir, "-S", buffer,
+           "-o", output, *[str(i) for i in inputs]]
+    env = dict(os.environ)
+    env["LC_ALL"] = "C"
+    subprocess.run(cmd, env=env, check=True)
+
+
+def _iter_tsv(path):
+    with open(path) as fh:
+        for line in fh:
+            yield line.rstrip("\n").split("\t")
+
+
+def _grouped(path):
+    """Yield (key, [rows]) for runs of rows sharing the first column. The
+    file must already be sorted on that column."""
+    cur = None
+    batch = []
+    for parts in _iter_tsv(path):
+        k = parts[0]
+        if cur is None:
+            cur = k
+        if k != cur:
+            yield cur, batch
+            cur, batch = k, []
+        batch.append(parts)
+    if batch:
+        yield cur, batch
+
+
+def _chunks(iterable, n):
+    chunk = []
+    for x in iterable:
+        chunk.append(x)
+        if len(chunk) >= n:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def _aggregate_edges(sorted_path, edges_path, selfs_path):
+    """Stream the sorted assertions; collapse each (a,b) run to one voted
+    edge (distinct asserters = votes). Real edges (a!=b) go to edges_path
+    and their endpoints into the returned dsu_nodes set (the one large
+    in-memory structure -- non-singleton nodes only); self-markers (a==b)
+    have their node written to selfs_path for the singleton pass."""
+    dsu_nodes = set()
+    n_edges = 0
+    with open(edges_path, "w") as fe, open(selfs_path, "w") as fs:
+        cur = None
+        votes = 0
+        last_as = None
+        for parts in _iter_tsv(sorted_path):
+            if len(parts) != 3:
+                continue
+            a, b, asserter = parts
+            key = (a, b)
+            if key != cur:
+                if cur is not None:
+                    if cur[0] == cur[1]:
+                        fs.write(f"{cur[0]}\n")
+                    else:
+                        fe.write(f"{cur[0]}\t{cur[1]}\t{votes}\n")
+                        dsu_nodes.add(cur[0])
+                        dsu_nodes.add(cur[1])
+                        n_edges += 1
+                cur = key
+                votes = 0
+                last_as = None
+            if asserter != last_as:
+                votes += 1
+                last_as = asserter
+        if cur is not None:
+            if cur[0] == cur[1]:
+                fs.write(f"{cur[0]}\n")
+            else:
+                fe.write(f"{cur[0]}\t{cur[1]}\t{votes}\n")
+                dsu_nodes.add(cur[0])
+                dsu_nodes.add(cur[1])
+                n_edges += 1
+    return dsu_nodes, n_edges
+
+
+def _attach_asserters(sorted_path, conflicts):
+    """Fill in the asserter lists for the (rare) refused links by a single
+    scan of the sorted assertions -- the vote aggregation dropped asserter
+    identities, but conflicts are few so we recover them by pair."""
+    want = {(c["pair"][0], c["pair"][1]): set() for c in conflicts}
+    if want:
+        for parts in _iter_tsv(sorted_path):
+            if len(parts) != 3:
+                continue
+            a, b, asserter = parts
+            s = want.get((a, b))
+            if s is not None:
+                s.add(asserter)
+    for c in conflicts:
+        c["asserters"] = sorted(want.get((c["pair"][0], c["pair"][1]), ()))
+
+
+def _build_clusters(edges_byvote, dsu_nodes, diffs, clusters_path):
+    """Constrained union-find over the vote-ordered edge file; write
+    ``root<TAB>member`` for every non-singleton node and return the conflict
+    report (asserters not yet attached)."""
+    dsu = DSU()
+    for n in dsu_nodes:
+        dsu.add(n)
+    stream = ((a, b, int(v)) for a, b, v in _iter_tsv(edges_byvote))
+    conflicts = _constrained_union(dsu, stream, diffs)
+    with open(clusters_path, "w") as fh:
+        for node in dsu.parent:
+            fh.write(f"{dsu.find(node)}\t{node}\n")
+    conflicts.sort(key=lambda c: (c["pair"][0], c["pair"][1]))
+    return conflicts
+
+
+def _append_singletons(selfs_sorted, dsu_nodes, clusters_path):
+    """Every distinct self-marked node that is not in a real cluster is its
+    own singleton cluster. Appended to the clusters file (which is re-sorted
+    by root afterwards)."""
+    n = 0
+    prev = None
+    with open(clusters_path, "a") as fh:
+        for parts in _iter_tsv(selfs_sorted):
+            node = parts[0]
+            if node == prev:
+                continue
+            prev = node
+            if node not in dsu_nodes:
+                fh.write(f"{node}\t{node}\n")
+                n += 1
+    return n
+
+
+def _fetch_prior_stream(idmap, clusters_sorted, out_path):
+    """Batched member -> prior-YUID lookup, streamed. Reads the by-root
+    clusters file and writes ``root<TAB>member<TAB>prior`` (prior blank when
+    the member had none), preserving order so the file stays grouped."""
+    conn = idmap.conn
+    with open(out_path, "w") as fout:
+        for chunk in _chunks(_iter_tsv(clusters_sorted), BATCH):
+            pipe = conn.pipeline(transaction=False)
+            for root, member in chunk:
+                pipe.get(idmap._manage_key_in(member))
+            vals = pipe.execute(raise_on_error=False)
+            for (root, member), val in zip(chunk, vals):
+                prior = ""
+                if isinstance(val, str) and val:
+                    prior = idmap._manage_value_out(val)
+                fout.write(f"{root}\t{member}\t{prior}\n")
+
+
+def _emit_claims(clusters_prior, prefix_out, claims_path, detail_path):
+    """Per cluster (grouped by root): compute the full-URI cluster key (min
+    over expanded members -- byte-identical to the in-memory min member),
+    tally prior YUIDs into one claim, and write the detail rows the apply
+    pass needs. Returns the cluster count."""
+    n_clusters = 0
+    with open(claims_path, "w") as fc, open(detail_path, "w") as fd:
+        for _root, rows in _grouped(clusters_prior):
+            members = [(r[1], r[2] if len(r) > 2 else "") for r in rows]
+            full_key = min(expand(m, prefix_out) for m, _ in members)
+            claim = _best_claim(p for _, p in members)
+            if claim:
+                best, votes = claim
+                fc.write(f"{best}\t{votes}\t{full_key}\n")
+            for m, p in members:
+                fd.write(f"{full_key}\t{m}\t{p}\n")
+            n_clusters += 1
+    return n_clusters
+
+
+def _resolve_claims(claims_sorted, won_path):
+    """Claims are sorted (yuid asc, votes desc, key asc), so the first row of
+    each yuid group is the winner; it keeps the YUID, everyone else mints."""
+    with open(won_path, "w") as fh:
+        for yuid, rows in _grouped(claims_sorted):
+            winner = rows[0]  # (yuid, votes, full_key)
+            fh.write(f"{winner[2]}\t{yuid}\n")
+
+
+def _apply_stream(idmap, configs, detail_sorted, won_sorted, touched_path):
+    """Merge the by-key detail with the by-key winners, minting where a
+    cluster kept no prior YUID, and bulk-load the result into redis. Old
+    yuid keys that lost a member are appended to touched_path for the final
+    dead-set sweep."""
+    conn = idmap.conn
+    token = idmap.update_token
+    stats = {"set": 0, "moved": 0, "clusters": 0}
+
+    won = _grouped(won_sorted)
+    won_key = None
+    won_yuid = None
+
+    def advance_to(key):
+        nonlocal won_key, won_yuid
+        while True:
+            if won_key is not None and won_key >= key:
+                return
+            try:
+                k, rows = next(won)
+            except StopIteration:
+                won_key = None
+                won_yuid = None
+                return
+            won_key, won_yuid = k, rows[0][1]
+
+    pipe = conn.pipeline(transaction=False)
+    ops = 0
+    with open(touched_path, "w") as ftouched:
+        for full_key, rows in _grouped(detail_sorted):
+            advance_to(full_key)
+            if won_key == full_key:
+                yuid = won_yuid
+            else:
+                yuid = mint_yuid(configs, full_key)
+            iyuid = idmap._manage_value_in(yuid)
+            imembers = []
+            for r in rows:
+                member = r[1]
+                prior = r[2] if len(r) > 2 else ""
+                im = idmap._manage_key_in(member)
+                imembers.append(im)
+                if prior and prior != yuid:
+                    iold = idmap._manage_value_in(prior)
+                    pipe.srem(iold, im)
+                    ftouched.write(f"{iold}\n")
+                    stats["moved"] += 1
+                pipe.set(im, iyuid)
+                stats["set"] += 1
+                ops += 1
+            pipe.sadd(iyuid, *imembers, token)
+            ops += 1
+            stats["clusters"] += 1
+            if ops >= BATCH:
+                pipe.execute(raise_on_error=False)
+                pipe = conn.pipeline(transaction=False)
+                ops = 0
+        if ops:
+            pipe.execute(raise_on_error=False)
     return stats
+
+
+def _distinct(path):
+    prev = None
+    for parts in _iter_tsv(path):
+        if parts and parts[0] != prev:
+            prev = parts[0]
+            yield prev
 
 
 def resolve_identity(configs, idmap, assertion_files, diff_index=None,
-                     conflicts_file="identity_conflicts.jsonl"):
-    """Aggregate -> cluster -> assign -> bulk-load. Returns stats."""
-    print("loading assertions...")
-    edges = load_assertions(assertion_files)
-    nodes = set()
-    for (a, b) in edges:
-        nodes.add(a)
-        nodes.add(b)
+                     conflicts_file="identity_conflicts.jsonl",
+                     work_dir=None, keep_temp=False):
+    """Resolve the identity map from the assertion logs, streaming through
+    unix ``sort`` so peak memory scales with the non-singleton subgraph
+    rather than the total record count. Returns stats.
 
-    print("loading diff pairs...")
-    diffs = load_diff_pairs(diff_index, nodes)
+    The steps mirror the in-memory reference (load_assertions -> cluster ->
+    assign -> apply_assignments) exactly, done on disk:
 
-    print("clustering...")
-    clusters, conflicts = cluster(edges, diffs)
-    with open(conflicts_file, "w") as fh:
-        for c in conflicts:
-            fh.write(json.dumps(c) + "\n")
+      1. sort every assertion line by (a, b, asserter)
+      2. stream -> voted real edges + self-markers; collect non-singleton
+         nodes (the only large in-memory set)
+      3. re-sort edges most-voted-first and run the constrained union-find
+      4. singletons (self-marked, not in a real cluster) join as 1-member
+         clusters
+      5. per cluster: tally prior YUIDs, resolve split contention by sort,
+         mint where there is no prior
+      6. bulk-load into redis, then sweep now-empty old YUID sets
+    """
+    prefix_in = idmap.prefix_map_in
+    prefix_out = idmap.prefix_map_out
+    buffer = os.getenv("LUX_SORT_BUFFER", "1G")
 
-    print("fetching prior...")
-    prior = fetch_prior(idmap, nodes)
-    print("assigning...")
-    yuids = assign(clusters, prior, configs)
+    if work_dir is None:
+        work_dir = "."
+    td = tempfile.mkdtemp(prefix="identity-", dir=work_dir)
+    p = lambda name: os.path.join(td, name)
+    try:
+        srt = p("assertions.sorted")
+        edg = p("edges.tsv")
+        slf = p("selfs.tsv")
+        slf_s = p("selfs.sorted")
+        edgv = p("edges.byvote")
+        clu = p("clusters.tsv")
+        clus = p("clusters.sorted")
+        clup = p("clusters.prior")
+        clm = p("claims.tsv")
+        clms = p("claims.sorted")
+        det = p("detail.tsv")
+        dets = p("detail.sorted")
+        won = p("won.tsv")
+        wons = p("won.sorted")
+        tch = p("touched.tsv")
+        tch_s = p("touched.sorted")
 
-    print("applying assignments...")
-    stats = apply_assignments(idmap, clusters, yuids, prior)
-    stats.update({
-        "pairs": len(edges),
-        "nodes": len(nodes),
-        "diff_pairs": len(diffs),
-        "conflicts": len(conflicts),
-    })
-    return stats
+        print("sorting assertions...")
+        _sort(assertion_files, srt,
+              ["-k1,1", "-k2,2", "-k3,3"], td, buffer)
+
+        print("aggregating voted edges...")
+        dsu_nodes, n_edges = _aggregate_edges(srt, edg, slf)
+
+        print("loading diff pairs...")
+        diffs = load_diff_pairs(diff_index, dsu_nodes, prefix_in=prefix_in)
+
+        print("clustering...")
+        _sort([edg], edgv, ["-k3,3nr", "-k1,1", "-k2,2"], td, buffer)
+        conflicts = _build_clusters(edgv, dsu_nodes, diffs, clu)
+        _attach_asserters(srt, conflicts)
+        with open(conflicts_file, "w") as fh:
+            for c in conflicts:
+                fh.write(json.dumps(c) + "\n")
+
+        print("adding singletons...")
+        _sort([slf], slf_s, ["-u", "-k1,1"], td, buffer)
+        n_singletons = _append_singletons(slf_s, dsu_nodes, clu)
+        _sort([clu], clus, ["-k1,1"], td, buffer)
+
+        print("fetching prior...")
+        _fetch_prior_stream(idmap, clus, clup)
+
+        print("assigning...")
+        n_clusters = _emit_claims(clup, prefix_out, clm, det)
+        _sort([clm], clms, ["-k1,1", "-k2,2nr", "-k3,3"], td, buffer)
+        _resolve_claims(clms, won)
+
+        print("applying assignments...")
+        _sort([det], dets, ["-k1,1"], td, buffer)
+        _sort([won], wons, ["-k1,1"], td, buffer)
+        stats = _apply_stream(idmap, configs, dets, wons, tch)
+
+        _sort([tch], tch_s, ["-u", "-k1,1"], td, buffer)
+        stats["deleted_yuids"] = _delete_dead_yuids(idmap, _distinct(tch_s))
+
+        stats.update({
+            "pairs": n_edges,
+            "nodes": len(dsu_nodes) + n_singletons,
+            "diff_pairs": len(diffs),
+            "conflicts": len(conflicts),
+            "clusters": n_clusters,
+            "singletons": n_singletons,
+        })
+        return stats
+    finally:
+        if not keep_temp:
+            shutil.rmtree(td, ignore_errors=True)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from pipeline.process.identity import (AssertionWriter, assign, cluster,
-                                       load_assertions, mint_yuid)
+from pipeline.process.identity import (AssertionWriter, assign,
+                                       build_prefix_maps, cluster, expand,
+                                       load_assertions, mint_yuid, shorten)
 
 
 class StubConfigs:
@@ -19,6 +20,12 @@ class StubConfigs:
     ok_record_types = {"Type": "concept", "Person": "person",
                        "Material": "concept"}
     parent_record_types = {"Material": "Type"}
+    # mirrors the shape Config exposes to build_prefix_maps: name -> cfg
+    external = {
+        "aat": {"name": "aat", "namespace": "http://vocab.getty.edu/aat/"},
+        "wikidata": {"name": "wikidata",
+                     "namespace": "http://www.wikidata.org/entity/"},
+    }
 
     def is_qua(self, recid):
         return "##qua" in recid
@@ -137,8 +144,23 @@ def test_mint_is_deterministic_and_slugged():
     assert mint_yuid(CFGS, "http://example.org/p/1##quaPerson") != y1
 
 
+def test_shorten_expand_round_trip():
+    prefix_in, prefix_out = build_prefix_maps(CFGS)
+    for full in ("http://vocab.getty.edu/aat/300055647##quaType",
+                 "http://www.wikidata.org/entity/Q1##quaType",
+                 "https://lux.collections.yale.edu/data/concept/x##quaType",
+                 # no matching namespace -> passes through unchanged
+                 "http://example.org/rec/1##quaType"):
+        short = shorten(full, prefix_in)
+        assert expand(short, prefix_out) == full
+    # the qua suffix survives shortening
+    assert shorten("http://vocab.getty.edu/aat/1##quaType",
+                   prefix_in) == "aat:1##quaType"
+
+
 def test_assertion_writer_round_trip(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    prefix_in, _ = build_prefix_maps(CFGS)
     w = AssertionWriter(CFGS, 3)
     w.write_record({"data": {
         "id": "http://example.org/rec/1", "type": "Material",
@@ -150,13 +172,17 @@ def test_assertion_writer_round_trip(tmp_path, monkeypatch):
     w.close()
 
     edges = load_assertions([tmp_path / "assertions-3.tsv"])
-    rec1 = "http://example.org/rec/1##quaType"  # Material quas to Type
     pairs = set(edges)
-    assert (sorted([rec1, "http://vocab.getty.edu/aat/1##quaType"])[0],
-            sorted([rec1, "http://vocab.getty.edu/aat/1##quaType"])[1]) in pairs
+    # URIs are stored in shortened (curie) form; the record id has no
+    # matching namespace so it stays full
+    rec1 = "http://example.org/rec/1##quaType"  # Material quas to Type
+    aat1 = "aat:1##quaType"
+    assert tuple(sorted([rec1, aat1])) in pairs
     self_pair = ("http://example.org/rec/2##quaPerson",
                  "http://example.org/rec/2##quaPerson")
     assert self_pair in pairs
+    # asserter (col3) is always the record's own id
+    assert all(a == rec1 for a in edges[tuple(sorted([rec1, aat1]))])
     # self assertions register the node but never merge anything
     clusters, _ = cluster(edges, set())
     assert len(clusters) == 2

--- a/tests/test_identity_streaming.py
+++ b/tests/test_identity_streaming.py
@@ -1,0 +1,351 @@
+"""Parity + correctness tests for the streaming resolve_identity pipeline.
+
+The streaming path (external ``sort`` + streaming Python) must reproduce the
+in-memory reference (load_assertions -> cluster -> assign -> apply). These
+tests exercise the whole pipeline against an in-memory fake idmap (no redis)
+and compare the resulting identity map / cluster partition to the reference.
+"""
+
+import glob
+import random
+import sys
+import uuid
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pipeline.process import identity as I
+from pipeline.process.identity import (AssertionWriter, build_prefix_maps,
+                                        cluster, expand, load_assertions,
+                                        resolve_identity, shorten)
+
+
+# ---------------------------------------------------------------------------
+# stubs
+# ---------------------------------------------------------------------------
+
+class StubConfigs:
+    internal_uri = "https://lux.collections.yale.edu/data/"
+    ok_record_types = {"Type": "concept", "Person": "person"}
+    parent_record_types = {}
+    external = {
+        "aat": {"name": "aat", "namespace": "http://vocab.getty.edu/aat/"},
+        "wikidata": {"name": "wikidata",
+                     "namespace": "http://www.wikidata.org/entity/"},
+        "viaf": {"name": "viaf", "namespace": "http://viaf.org/viaf/"},
+    }
+
+    def is_qua(self, recid):
+        return "##qua" in recid
+
+    def make_qua(self, recid, typ):
+        if "##qua" in recid:
+            return recid
+        typ = self.parent_record_types.get(typ, typ)
+        return f"{recid}##qua{typ}"
+
+    def split_qua(self, recid):
+        return recid.split("##qua")
+
+
+CFGS = StubConfigs()
+
+
+class _FakePipe:
+    def __init__(self, store):
+        self.store = store
+        self.ops = []
+
+    def get(self, k):
+        self.ops.append(("get", k))
+
+    def set(self, k, v):
+        self.ops.append(("set", k, v))
+
+    def sadd(self, k, *vs):
+        self.ops.append(("sadd", k, vs))
+
+    def srem(self, k, v):
+        self.ops.append(("srem", k, v))
+
+    def smembers(self, k):
+        self.ops.append(("smembers", k))
+
+    def delete(self, k):
+        self.ops.append(("delete", k))
+
+    def execute(self, raise_on_error=False):
+        res = []
+        for op in self.ops:
+            t = op[0]
+            if t == "get":
+                v = self.store.get(op[1])
+                res.append(v if isinstance(v, str) else None)
+            elif t == "set":
+                self.store[op[1]] = op[2]
+                res.append(True)
+            elif t == "sadd":
+                s = self.store.get(op[1])
+                if not isinstance(s, set):
+                    s = set()
+                    self.store[op[1]] = s
+                s.update(op[2])
+                res.append(len(op[2]))
+            elif t == "srem":
+                s = self.store.get(op[1])
+                if isinstance(s, set):
+                    s.discard(op[2])
+                res.append(1)
+            elif t == "smembers":
+                s = self.store.get(op[1])
+                res.append(set(s) if isinstance(s, set) else set())
+            elif t == "delete":
+                self.store.pop(op[1], None)
+                res.append(1)
+        self.ops = []
+        return res
+
+
+class _FakeConn:
+    def __init__(self):
+        self.store = {}
+
+    def pipeline(self, transaction=False):
+        return _FakePipe(self.store)
+
+
+class FakeIdMap:
+    """Minimal stand-in for storage.idmap.redis.IdMap: same prefix maps and
+    same forward/reverse storage shape, backed by an in-memory dict."""
+
+    def __init__(self, configs, token="__testtok__"):
+        self.configs = configs
+        self.prefix_map_in, self.prefix_map_out = build_prefix_maps(configs)
+        self.conn = _FakeConn()
+        self.update_token = token
+
+    def _manage_key_in(self, k):
+        return shorten(k, self.prefix_map_in)
+
+    def _manage_key_out(self, k):
+        return expand(k, self.prefix_map_out)
+
+    _manage_value_in = _manage_key_in
+    _manage_value_out = _manage_key_out
+
+    def seed(self, member_full, yuid_full):
+        im = self._manage_key_in(member_full)
+        iy = self._manage_value_in(yuid_full)
+        self.conn.store[im] = iy
+        s = self.conn.store.get(iy)
+        if not isinstance(s, set):
+            s = set()
+            self.conn.store[iy] = s
+        s.add(im)
+        s.add(self.update_token)
+
+    def forward(self):
+        """Full member URI -> full YUID for every string-valued key."""
+        out = {}
+        for k, v in self.conn.store.items():
+            if isinstance(v, str):
+                out[self._manage_key_out(k)] = self._manage_value_out(v)
+        return out
+
+    def yuid_set(self, yuid_full):
+        return set(self.conn.store.get(self._manage_value_in(yuid_full), set()))
+
+
+# ---------------------------------------------------------------------------
+# synthetic data
+# ---------------------------------------------------------------------------
+
+NAMESPACES = [
+    "http://vocab.getty.edu/aat/",
+    "http://www.wikidata.org/entity/",
+    "http://viaf.org/viaf/",
+    "https://lux.collections.yale.edu/data/concept/",
+    "http://example.org/unmatched/",   # no namespace -> stays full
+]
+
+
+def _uri(rng, n):
+    return rng.choice(NAMESPACES) + f"{n}"
+
+
+def make_clusters(rng, n_clusters):
+    """Random member sets; ~half are singletons, the rest size 2-5."""
+    clusters = []
+    counter = [0]
+
+    def fresh():
+        counter[0] += 1
+        return _uri(rng, counter[0])
+
+    for _ in range(n_clusters):
+        if rng.random() < 0.5:
+            clusters.append([fresh()])
+        else:
+            size = rng.randint(2, 5)
+            clusters.append([fresh() for _ in range(size)])
+    return clusters
+
+
+def write_assertions(clusters, out_dir, n_slices, rng):
+    """Emit each cluster as records-with-equivalents through AssertionWriter,
+    sharded across slices in shuffled order (proves order independence)."""
+    writers = [AssertionWriter(CFGS, s) for s in range(n_slices)]
+    jobs = []
+    for members in clusters:
+        for m in members:
+            eqs = [{"id": o, "type": "Type"} for o in members if o != m]
+            jobs.append({"data": {"id": m, "type": "Type", "equivalent": eqs}})
+    rng.shuffle(jobs)
+    for rec in jobs:
+        rng.choice(writers).write_record(rec)
+    for w in writers:
+        w.close()
+    return sorted(glob.glob(str(Path(out_dir) / "assertions-*.tsv")))
+
+
+def qua(uri):
+    return f"{uri}##quaType"
+
+
+def reference_partition(files):
+    """The in-memory reference cluster partition, as full-URI member sets."""
+    _, prefix_out = build_prefix_maps(CFGS)
+    edges = load_assertions([Path(f) for f in files])
+    clusters, _ = cluster(edges, set())
+    parts = set()
+    for members in clusters.values():
+        parts.add(frozenset(expand(m, prefix_out) for m in members))
+    return parts
+
+
+def streaming_partition(idmap):
+    """Reconstruct the partition from the idmap forward map: members sharing
+    a YUID are in the same cluster."""
+    by_yuid = defaultdict(set)
+    for member, yuid in idmap.forward().items():
+        by_yuid[yuid].add(member)
+    return {frozenset(v) for v in by_yuid.values()}
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+def test_stream_partition_matches_reference(tmp_path, monkeypatch):
+    """No priors -> every cluster mints a unique YUID, so members grouped by
+    YUID recover exactly the reference cluster partition."""
+    monkeypatch.chdir(tmp_path)
+    for seed in range(6):
+        rng = random.Random(seed)
+        work = tmp_path / f"run{seed}"
+        work.mkdir()
+        monkeypatch.chdir(work)
+        clusters = make_clusters(rng, 60)
+        files = write_assertions(clusters, work, 4, rng)
+
+        idmap = FakeIdMap(CFGS)
+        stats = resolve_identity(CFGS, idmap, files, work_dir=str(work),
+                                 conflicts_file=str(work / "conf.jsonl"))
+
+        assert streaming_partition(idmap) == reference_partition(files)
+        # one distinct YUID per cluster (all minted, all unique)
+        assert stats["clusters"] == len(clusters)
+        assert len(set(idmap.forward().values())) == len(clusters)
+
+
+def test_stream_prior_reuse_exact(tmp_path, monkeypatch):
+    """Every member seeded with its cluster's prior YUID -> every cluster
+    reuses it; forward map must equal the seeded map exactly."""
+    monkeypatch.chdir(tmp_path)
+    rng = random.Random(99)
+    clusters = make_clusters(rng, 80)
+    files = write_assertions(clusters, tmp_path, 3, rng)
+
+    idmap = FakeIdMap(CFGS)
+    expected = {}
+    for i, members in enumerate(clusters):
+        y = f"{CFGS.internal_uri}concept/prior-{i}"
+        for m in members:
+            idmap.seed(qua(m), y)
+            expected[qua(m)] = y
+
+    resolve_identity(CFGS, idmap, files, work_dir=str(tmp_path),
+                     conflicts_file=str(tmp_path / "conf.jsonl"))
+    assert idmap.forward() == expected
+
+
+def test_stream_minority_moves_and_old_set_cleaned(tmp_path, monkeypatch):
+    """A 3-member cluster: two members held YUID-A, one held YUID-B. The
+    majority YUID-A wins, the minority member moves to A, and YUID-B (now
+    holding only the update token) is deleted."""
+    monkeypatch.chdir(tmp_path)
+    rng = random.Random(7)
+    members = [_uri(rng, i) for i in range(3)]
+    files = write_assertions([members], tmp_path, 1, rng)
+
+    idmap = FakeIdMap(CFGS)
+    ya = f"{CFGS.internal_uri}concept/AAA"
+    yb = f"{CFGS.internal_uri}concept/BBB"
+    idmap.seed(qua(members[0]), ya)
+    idmap.seed(qua(members[1]), ya)
+    idmap.seed(qua(members[2]), yb)
+
+    stats = resolve_identity(CFGS, idmap, files, work_dir=str(tmp_path),
+                             conflicts_file=str(tmp_path / "conf.jsonl"))
+
+    fwd = idmap.forward()
+    assert fwd[qua(members[0])] == ya
+    assert fwd[qua(members[1])] == ya
+    assert fwd[qua(members[2])] == ya            # moved from B to A
+    assert idmap.yuid_set(ya) == {idmap._manage_key_in(qua(m))
+                                  for m in members} | {idmap.update_token}
+    assert idmap.yuid_set(yb) == set()           # B deleted (token-only)
+    assert stats["moved"] == 1
+    assert stats["deleted_yuids"] == 1
+
+
+class _DiffIndex:
+    def __init__(self, mapping):
+        self._m = mapping  # full uri -> full uri (single value)
+
+    def keys(self):
+        return list(self._m.keys())
+
+    def __getitem__(self, k):
+        return self._m[k]
+
+
+def test_stream_differentfrom_keeps_separate(tmp_path, monkeypatch):
+    """A chain A-B-C-D with differentFrom(A, D): the link that would connect
+    A and D transitively is refused, so A and D land in different clusters."""
+    monkeypatch.chdir(tmp_path)
+    rng = random.Random(3)
+    a = "http://vocab.getty.edu/aat/1"
+    b = "http://www.wikidata.org/entity/2"
+    c = "http://viaf.org/viaf/3"
+    d = "http://example.org/unmatched/4"
+    # three separate records make the chain A-B, B-C, C-D
+    clusters_records = [[a, b], [b, c], [c, d]]
+    files = write_assertions(clusters_records, tmp_path, 2, rng)
+
+    diff = _DiffIndex({a: d})
+    idmap = FakeIdMap(CFGS)
+    stats = resolve_identity(CFGS, idmap, files, diff_index=diff,
+                             work_dir=str(tmp_path),
+                             conflicts_file=str(tmp_path / "conf.jsonl"))
+
+    fwd = idmap.forward()
+    assert fwd[qua(a)] != fwd[qua(d)]
+    assert stats["conflicts"] == 1
+    conf = (tmp_path / "conf.jsonl").read_text().strip().splitlines()
+    assert len(conf) == 1
+    # the refused link is reported with its asserter(s)
+    import json as _json
+    rec = _json.loads(conf[0])
+    assert rec["asserters"]


### PR DESCRIPTION

Testing on full dataset:

| Metric | Value |
| -- | -- |
| distinct URIs (nodes) | 50,695,981 |
| singletons | 39,920,600 (79%) 
| non-singleton nodes (the in-RAM DSU) | 10,775,381
| distinct voted edges | 11,827,177
| final clusters | 43,873,139
| wall time | 503 s (~8.4 min)
| Python peak RSS | 6.2 GB
| sort child peak RSS | 4.1 GB
